### PR TITLE
Add Inspector ScanSbom action

### DIFF
--- a/.github/workflows/inspector_scan.yaml
+++ b/.github/workflows/inspector_scan.yaml
@@ -22,7 +22,7 @@ jobs:
 
      - name: Scan project with Inspector
        id: inspector
-       uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+       uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
        with:
          artifact_type: 'repository'
          artifact_path: './'

--- a/.github/workflows/inspector_scan.yaml
+++ b/.github/workflows/inspector_scan.yaml
@@ -1,0 +1,51 @@
+name: Scan repo with Inspector
+
+on: [push]
+jobs:
+ daily_job:
+   runs-on: ubuntu-latest
+
+   environment:
+     name: InspectorScanSbom
+
+   steps:
+     - name: Configure AWS credentials
+       uses: aws-actions/configure-aws-credentials@v4
+       with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+
+     - name: Checkout repository
+       uses: actions/checkout@v4
+
+     - name: Scan project with Inspector
+       id: inspector
+       uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+       with:
+         artifact_type: 'repository'
+         artifact_path: './'
+         display_vulnerability_findings: "enabled"
+         critical_threshold: 1
+         high_threshold: 1
+         medium_threshold: 1
+         low_threshold: 1
+         other_threshold: 1
+
+     - name: Display SBOM
+       run: cat ${{ steps.inspector.outputs.artifact_sbom }}
+
+     - name: Display vulnerability scan
+       run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
+
+     - name: Upload scan results
+       uses: actions/upload-artifact@v4
+       with:
+         name: Inspector Vulnerability Scan Artifacts
+         path: |
+           ${{ steps.inspector.outputs.inspector_scan_results }}
+           ${{ steps.inspector.outputs.artifact_sbom }}
+
+     - name: Fail if vulns detected
+       run: exit ${{ steps.inspector.outputs.vulnerability_threshold_exceeded }}


### PR DESCRIPTION
This adds the [Amazon Inspector GitHub Action](https://github.com/marketplace/actions/vulnerability-scan-github-action-for-amazon-inspector) to this project's workflows so that we can scan the project for vulnerabilities.

See here for an example scan:
https://github.com/aws/amazon-inspector-container-image-scanner-jenkins-plugin/actions/runs/8898717647

Please note that this action will not yield vulnerabilities at this time because inspector-sbomgen expects either `pom.properties` or a JAR file to be present, which is not the case in this repo.

We are exploring alternatives such as processing `pom.xml` - these changes will not impact this PR because it downloads _inspector-sbomgen:latest_.