### PR TITLE
Fixing Automatic SBOMGen Download for agent machines.

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -77,6 +77,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
     private final String credentialId;
     private final String oidcCredentialId;
     private final boolean isThresholdEnabled;
+    private final boolean thresholdEquals;
     private final String sbomgenPath;
     private final String sbomgenSource;
     private final boolean osArch;
@@ -91,8 +92,8 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
     @DataBoundConstructor
     public AmazonInspectorBuilder(String archivePath, String artifactPath, String archiveType, String sbomgenPath, boolean osArch, String iamRole,
                                   String awsRegion, String credentialId, String awsProfileName, String awsCredentialId,
-                                  String sbomgenMethod, String sbomgenSource, boolean isThresholdEnabled, int countCritical,
-                                  int countHigh, int countMedium, int countLow, String oidcCredentialId) {
+                                  String sbomgenMethod, String sbomgenSource, boolean isThresholdEnabled, boolean thresholdEquals,
+                                  int countCritical, int countHigh, int countMedium, int countLow, String oidcCredentialId) {
         if (artifactPath != null && !artifactPath.isEmpty()) {
             this.archivePath = artifactPath;
         } else {
@@ -110,6 +111,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         this.iamRole = iamRole;
         this.awsRegion = awsRegion;
         this.isThresholdEnabled = isThresholdEnabled;
+        this.thresholdEquals = thresholdEquals;
         this.countCritical = countCritical;
         this.countHigh = countHigh;
         this.countMedium = countMedium;
@@ -122,6 +124,15 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         boolean mediumExceedsLimit = counts.get(Severity.MEDIUM) > countMedium;
         boolean lowExceedsLimit = counts.get(Severity.LOW) > countLow;
 
+        boolean criticalEqualsLimit = counts.get(Severity.CRITICAL) == countCritical;
+        boolean highEqualsLimit = counts.get(Severity.HIGH) == countHigh;
+        boolean mediumEqualsLimit = counts.get(Severity.MEDIUM) == countMedium;
+        boolean lowEqualsLimit = counts.get(Severity.LOW) == countLow;
+
+        if (this.thresholdEquals) {
+            logger.println("Threshold should equal vulnerabilites, regression testing.");
+            return !(criticalEqualsLimit && highEqualsLimit && mediumEqualsLimit && lowEqualsLimit);
+        }
         return criticalExceedsLimit || highExceedsLimit || mediumExceedsLimit || lowExceedsLimit;
     }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,26 +1,28 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import org.jenkinsci.remoting.RoleChecker;
 
 import javax.management.openmbean.InvalidKeyException;
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.Files;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class SbomgenDownloader {
 
-    public static String getBinary(String configInput) throws IOException {
+    public static String getBinary(String configInput, FilePath workspace) throws IOException, InterruptedException, ExecutionException {
         String url = getUrl(configInput);
-        String zipPath = downloadFile(url);
+        FilePath zipPath = downloadFile(url, workspace);
         return unzipFile(zipPath);
     }
 
@@ -45,23 +47,10 @@ public class SbomgenDownloader {
         throw new InvalidKeyException("No url corresponding to " + configInput);
     }
 
-    private static String downloadFile(String url) throws IOException {
-        String tmpdir = Files.createTempDirectory("sbomgen").toFile().getAbsolutePath();
-        String sbomgenPath = tmpdir + "/inspector_sbomgen.zip";
-
-        try (BufferedInputStream in = new BufferedInputStream(new URL(url).openStream());
-             FileOutputStream fileOutputStream = new FileOutputStream(sbomgenPath)) {
-            byte dataBuffer[] = new byte[1024];
-            int bytesRead;
-            while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
-                fileOutputStream.write(dataBuffer, 0, bytesRead);
-            }
-        } catch (IOException e) {
-            throw new IOException("There was an issue downloading the SBOMGen utility, please run the plugin by " +
-                    "providing the utility manually.");
-        }
-
-        return sbomgenPath;
+    private static FilePath downloadFile(String url, FilePath workspace) throws IOException, InterruptedException {
+        FilePath sbomgenZip = workspace.child("inspector-sbomgen.zip");
+        sbomgenZip.copyFrom(new BufferedInputStream(new URL(url).openStream()));
+        return sbomgenZip;
     }
 
     private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
@@ -79,44 +68,55 @@ public class SbomgenDownloader {
 
 
     @SuppressFBWarnings()
-    private static String unzipFile(String zipPath) throws IOException {
-        String destinationPath = zipPath.replace(".zip", "");
-        byte[] buffer = new byte[1024];
+    private static String unzipFile(FilePath zip) throws IOException, InterruptedException, ExecutionException {
+        FilePath destination = zip.getParent().child(zip.getRemote().replace(".zip", ""));
+        Future<String> callable = zip.actAsync(new FilePath.FileCallable<String>() {
+            @Override
+            public void checkRoles(RoleChecker checker) throws SecurityException {
 
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath));
-        ZipEntry zipEntry = zis.getNextEntry();
-        String sbomgenPath = "";
-        while (zipEntry != null) {
-            File newFile = newFile(new File(destinationPath), zipEntry);
-            if (zipEntry.getName().endsWith("inspector-sbomgen")) {
-                sbomgenPath = newFile.getAbsolutePath();
-                newFile.setExecutable(true);
             }
 
-            if (zipEntry.isDirectory()) {
-                if (!newFile.isDirectory() && !newFile.mkdirs()) {
-                    throw new IOException("Failed to create directory " + newFile);
-                }
-            } else {
-                File parent = newFile.getParentFile();
-                if (!parent.isDirectory() && !parent.mkdirs()) {
-                    throw new IOException("Failed to create directory " + parent);
+            @Override
+            public String invoke(File f, VirtualChannel channel) throws IOException {
+                byte[] buffer = new byte[1024];
+                ZipInputStream zis = new ZipInputStream(new FileInputStream(f));
+                ZipEntry zipEntry = zis.getNextEntry();
+                String sbomgenPath = "";
+                while (zipEntry != null) {
+                    File newFile = newFile(new File(destination.getRemote()), zipEntry);
+                    if (zipEntry.getName().endsWith("inspector-sbomgen")) {
+                        sbomgenPath = newFile.getAbsolutePath();
+                        newFile.setExecutable(true);
+                    }
+
+                    if (zipEntry.isDirectory()) {
+                        if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                            throw new IOException("Failed to create directory " + newFile);
+                        }
+                    } else {
+                        File parent = newFile.getParentFile();
+                        if (!parent.isDirectory() && !parent.mkdirs()) {
+                            throw new IOException("Failed to create directory " + parent);
+                        }
+
+                        FileOutputStream fos = new FileOutputStream(newFile);
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
+                        fos.close();
+                    }
+                    zipEntry = zis.getNextEntry();
                 }
 
-                FileOutputStream fos = new FileOutputStream(newFile);
-                int len;
-                while ((len = zis.read(buffer)) > 0) {
-                    fos.write(buffer, 0, len);
-                }
-                fos.close();
+                zis.closeEntry();
+                zis.close();
+
+
+                return sbomgenPath;
             }
-            zipEntry = zis.getNextEntry();
-        }
+        });
 
-        zis.closeEntry();
-        zis.close();
-
-
-        return sbomgenPath;
+        return callable.get();
     }
 }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,6 +1,5 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 
-import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
@@ -19,7 +18,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class SbomgenDownloader {
-
     public static String getBinary(String configInput, FilePath workspace) throws IOException, InterruptedException, ExecutionException {
         String url = getUrl(configInput);
         FilePath zipPath = downloadFile(url, workspace);
@@ -53,6 +51,68 @@ public class SbomgenDownloader {
         return sbomgenZip;
     }
 
+
+    @SuppressFBWarnings()
+    private static String unzipFile(FilePath zip) throws IOException, InterruptedException, ExecutionException {
+        FilePath destination = zip.getParent().child(zip.getRemote().replace(".zip", ""));
+        Future<String> callable = zip.actAsync(new DownloaderCallable(destination.getRemote()));
+
+        return callable.get();
+    }
+}
+
+class DownloaderCallable implements FilePath.FileCallable {
+    String destinationPath;
+
+    DownloaderCallable(String destinationPath) {
+        this.destinationPath = destinationPath;
+    }
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+
+    }
+
+    @Override
+    public String invoke(File f, VirtualChannel channel) throws IOException {
+        byte[] buffer = new byte[1024];
+        ZipInputStream zis = new ZipInputStream(new FileInputStream(f));
+        ZipEntry zipEntry = zis.getNextEntry();
+        String sbomgenPath = "";
+        while (zipEntry != null) {
+            File newFile = newFile(new File(destinationPath), zipEntry);
+            if (zipEntry.getName().endsWith("inspector-sbomgen")) {
+                sbomgenPath = newFile.getAbsolutePath();
+                newFile.setExecutable(true);
+            }
+
+            if (zipEntry.isDirectory()) {
+                if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                    throw new IOException("Failed to create directory " + newFile);
+                }
+            } else {
+                File parent = newFile.getParentFile();
+                if (!parent.isDirectory() && !parent.mkdirs()) {
+                    throw new IOException("Failed to create directory " + parent);
+                }
+
+                FileOutputStream fos = new FileOutputStream(newFile);
+                int len;
+                while ((len = zis.read(buffer)) > 0) {
+                    fos.write(buffer, 0, len);
+                }
+                fos.close();
+            }
+            zipEntry = zis.getNextEntry();
+        }
+
+        zis.closeEntry();
+        zis.close();
+
+
+        return sbomgenPath;
+    }
+
     private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
         File destFile = new File(destinationDir, zipEntry.getName());
 
@@ -64,59 +124,5 @@ public class SbomgenDownloader {
         }
 
         return destFile;
-    }
-
-
-    @SuppressFBWarnings()
-    private static String unzipFile(FilePath zip) throws IOException, InterruptedException, ExecutionException {
-        FilePath destination = zip.getParent().child(zip.getRemote().replace(".zip", ""));
-        Future<String> callable = zip.actAsync(new FilePath.FileCallable<String>() {
-            @Override
-            public void checkRoles(RoleChecker checker) throws SecurityException {
-
-            }
-
-            @Override
-            public String invoke(File f, VirtualChannel channel) throws IOException {
-                byte[] buffer = new byte[1024];
-                ZipInputStream zis = new ZipInputStream(new FileInputStream(f));
-                ZipEntry zipEntry = zis.getNextEntry();
-                String sbomgenPath = "";
-                while (zipEntry != null) {
-                    File newFile = newFile(new File(destination.getRemote()), zipEntry);
-                    if (zipEntry.getName().endsWith("inspector-sbomgen")) {
-                        sbomgenPath = newFile.getAbsolutePath();
-                        newFile.setExecutable(true);
-                    }
-
-                    if (zipEntry.isDirectory()) {
-                        if (!newFile.isDirectory() && !newFile.mkdirs()) {
-                            throw new IOException("Failed to create directory " + newFile);
-                        }
-                    } else {
-                        File parent = newFile.getParentFile();
-                        if (!parent.isDirectory() && !parent.mkdirs()) {
-                            throw new IOException("Failed to create directory " + parent);
-                        }
-
-                        FileOutputStream fos = new FileOutputStream(newFile);
-                        int len;
-                        while ((len = zis.read(buffer)) > 0) {
-                            fos.write(buffer, 0, len);
-                        }
-                        fos.close();
-                    }
-                    zipEntry = zis.getNextEntry();
-                }
-
-                zis.closeEntry();
-                zis.close();
-
-
-                return sbomgenPath;
-            }
-        });
-
-        return callable.get();
     }
 }


### PR DESCRIPTION
This CR uses Jenkins-supported methods to achieve automatic sbomgen download. 

```Started by user unknown or anonymous
Running as SYSTEM
Building remotely on [jenkinslab](http://localhost:8080/computer/jenkinslab) in workspace /home/ec2-user/workspace/Demo
Automatic SBOMGen Sourcing selected, downloading now...
No credential provided, running without.
Making downloaded SBOMGen executable...
$ chmod +x /home/ec2-user/workspace/Demo/inspector-sbomgen/inspector-sbomgen-1.3.2/linux/amd64/inspector-sbomgen
Running command...
[/home/ec2-user/workspace/Demo/inspector-sbomgen/inspector-sbomgen-1.3.2/linux/amd64/inspector-sbomgen, container, --image, alpine:latest]
$ /home/ec2-user/workspace/Demo/inspector-sbomgen/inspector-sbomgen-1.3.2/linux/amd64/inspector-sbomgen container --image alpine:latest
Sending SBOM to Inspector for validation with info: credential:null, role:arn:aws:iam::414879708742:role/CICDScan, profile:
Authenticating to STS via a role and default credential provider chain.
Converting SBOM Results to CSV.
Build Artifacts: http://localhost:8080/job/Demo/432/display/redirect?page=artifacts
Results: Critical: 0, High: 0, Medium: 0, Low: 0, Other: 0
Ignoring results due to thresholds being disabled.
Does Build Pass: true
Build step 'Amazon Inspector Scan' changed build result to SUCCESS
Finished: SUCCESS```