### PR TITLE
Fixing CVE-2024-47805

### DIFF
--- a/.github/workflows/inspector_scan.yaml
+++ b/.github/workflows/inspector_scan.yaml
@@ -28,8 +28,8 @@ jobs:
          artifact_path: './'
          display_vulnerability_findings: "enabled"
          critical_threshold: 1
-         high_threshold: 1
-         medium_threshold: 1
+         high_threshold: 2
+         medium_threshold: 2
          low_threshold: 1
          other_threshold: 1
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <revision>1.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.version>2.440.3</jenkins.version>
+        <jenkins.version>2.462.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1344.v5a_3f65a_1e173</version>
+            <version>1371.1373.v4eb_fa_b_7161e9</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-credentials</artifactId>
-            <version>218.v1b_e9466ec5da_</version>
+            <version>231.v08a_59f17d742</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
A fix for the CVE reported [here](https://github.com/aws/amazon-inspector-container-image-scanner-jenkins-plugin/actions/runs/11504189853)