### PR TITLE
Support for skip-files in Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>[338.v848422169819,)</version>
+            <version>338.v848422169819</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>338.v848422169819</version>
+            <version>[338.v848422169819,)</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -366,16 +366,14 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
         @Override
         public AmazonInspectorBuilder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            JSONObject sbomgenSelection = formData.getJSONObject("sbomgenSelection");
-            if (sbomgenSelection != null) {
-                String installationMethod = sbomgenSelection.getString("value");
-                formData.put("installationMethod", installationMethod);
-                if ("manual".equalsIgnoreCase(installationMethod)) {
-                    String sbomgenPath = sbomgenSelection.getString("sbomgenPath");
-                    formData.put("sbomgenPath", sbomgenPath);
-                }
+            String value = JSONObject.fromObject(formData.get("sbomgenSelection")).get("value").toString();
+
+            if (value.equals("manual")) {
+                formData.put("sbomgenPath", JSONObject.fromObject(formData.get("sbomgenSelection")).get("sbomgenPath"));
             }
-            formData.remove("sbomgenSelection");
+
+            formData.put("sbomgenSelection", value);
+
             return req.bindJSON(AmazonInspectorBuilder.class, formData);
         }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -1,5 +1,4 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
-
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.requests.SdkRequests;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenDownloader;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
@@ -25,7 +24,6 @@ import hudson.model.TaskListener;
 import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.util.ListBoxModel;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -36,7 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenRunner;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.csvconversion.CsvConverter;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.html.HtmlJarHandler;
@@ -49,7 +46,6 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severit
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.html.HtmlConversionUtils;
 import io.jenkins.plugins.oidc_provider.IdTokenFileCredentials;
 import io.jenkins.plugins.oidc_provider.IdTokenStringCredentials;
-
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import jenkins.util.BuildListenerAdapter;
@@ -59,7 +55,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.POST;
-
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.InspectorRegions.INSPECTOR_REGIONS;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeFilePath;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeUrl;
@@ -371,16 +366,16 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
         @Override
         public AmazonInspectorBuilder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            String value = JSONObject.fromObject(formData.get("sbomgenSelection")).get("value").toString();
-            formData.put("isAutomaticSbomgen", value.equals("automatic"));
-            formData.put("sbomgenMethod", value);
-
-            if (value.equals("manual")) {
-                formData.put("sbomgenPath", JSONObject.fromObject(formData.get("sbomgenSelection")).get("sbomgenPath"));
-            } else if (value.equals("automatic")) {
-                formData.put("sbomgenSource", JSONObject.fromObject(JSONObject.fromObject(formData.get("sbomgenSelection")).get("sbomgenSource")).get("value"));
+            JSONObject sbomgenSelection = formData.getJSONObject("sbomgenSelection");
+            if (sbomgenSelection != null) {
+                String installationMethod = sbomgenSelection.getString("value");
+                formData.put("installationMethod", installationMethod);
+                if ("manual".equalsIgnoreCase(installationMethod)) {
+                    String sbomgenPath = sbomgenSelection.getString("sbomgenPath");
+                    formData.put("sbomgenPath", sbomgenPath);
+                }
             }
-
+            formData.remove("sbomgenSelection");
             return req.bindJSON(AmazonInspectorBuilder.class, formData);
         }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -8,37 +8,26 @@ import java.util.concurrent.ExecutionException;
 
 public class SbomgenDownloader {
 
-    private static final String BASE_URL = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/%s/inspector-sbomgen.zip";
+    private static final String BASE_URL = "https://amazon-inspector-" +
+            "sbomgen.s3.amazonaws.com/latest/linux/%s/inspector-sbomgen.zip";
 
-    public static String getBinary(String configInput, FilePath workspace) throws IOException, InterruptedException, ExecutionException {
-        String url = getUrl(configInput);
+    public static String getBinary(FilePath workspace) throws IOException, InterruptedException, ExecutionException {
+        String url = getUrl();
         FilePath zipPath = downloadFile(url, workspace);
         return unzipFile(zipPath);
     }
 
-    private static String getUrl(String configInput) {
+    private static String getUrl() {
         String osName = System.getProperty("os.name").toLowerCase();
         if (!osName.contains("linux")) {
             throw new UnsupportedOperationException("Unsupported OS: " + osName);
         }
-
         String architecture = "amd64";
-
         String osArch = System.getProperty("os.arch").toLowerCase();
         if (osArch.contains("arm64") || osArch.contains("aarch64")) {
             architecture = "arm64";
         } else if (!osArch.contains("amd64") && !osArch.contains("x86_64")) {
             throw new UnsupportedOperationException("Unsupported architecture: " + osArch);
-        }
-
-        if (configInput != null && !configInput.isEmpty()) {
-            if (configInput.equalsIgnoreCase("linuxAmd64")) {
-                architecture = "amd64";
-            } else if (configInput.equalsIgnoreCase("linuxArm64")) {
-                architecture = "arm64";
-            } else {
-                throw new IllegalArgumentException("Invalid configInput: " + configInput);
-            }
         }
         return String.format(BASE_URL, architecture);
     }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,14 +1,15 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
-import javax.management.openmbean.InvalidKeyException;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 public class SbomgenDownloader {
+
+    private static final String BASE_URL = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/%s/inspector-sbomgen.zip";
+
     public static String getBinary(String configInput, FilePath workspace) throws IOException, InterruptedException, ExecutionException {
         String url = getUrl(configInput);
         FilePath zipPath = downloadFile(url, workspace);
@@ -16,24 +17,30 @@ public class SbomgenDownloader {
     }
 
     private static String getUrl(String configInput) {
-        final String linuxAmd64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/amd64/inspector-sbomgen.zip";
-        final String linuxArm64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/arm64/inspector-sbomgen.zip";
-
-        switch (configInput) {
-            case "linuxAmd64":
-                return linuxAmd64Url;
-            case "linuxArm64":
-                return linuxArm64Url;
-        }
-        if ("linuxAmd64Url".equals(configInput)) {
-            return linuxAmd64Url;
-        }
-        if ("linuxArm64Url".equals(configInput)) {
-            return linuxArm64Url;
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (!osName.contains("linux")) {
+            throw new UnsupportedOperationException("Unsupported OS: " + osName);
         }
 
+        String architecture = "amd64";
 
-        throw new InvalidKeyException("No url corresponding to " + configInput);
+        String osArch = System.getProperty("os.arch").toLowerCase();
+        if (osArch.contains("arm64") || osArch.contains("aarch64")) {
+            architecture = "arm64";
+        } else if (!osArch.contains("amd64") && !osArch.contains("x86_64")) {
+            throw new UnsupportedOperationException("Unsupported architecture: " + osArch);
+        }
+
+        if (configInput != null && !configInput.isEmpty()) {
+            if (configInput.equalsIgnoreCase("linuxAmd64")) {
+                architecture = "amd64";
+            } else if (configInput.equalsIgnoreCase("linuxArm64")) {
+                architecture = "arm64";
+            } else {
+                throw new IllegalArgumentException("Invalid configInput: " + configInput);
+            }
+        }
+        return String.format(BASE_URL, architecture);
     }
 
     private static FilePath downloadFile(String url, FilePath workspace) throws IOException, InterruptedException {
@@ -42,12 +49,12 @@ public class SbomgenDownloader {
         return sbomgenZip;
     }
 
-
-    @SuppressFBWarnings()
-    private static String unzipFile(FilePath zip) throws IOException, InterruptedException, ExecutionException {
-        FilePath destination = zip.getParent().child(zip.getRemote().replace(".zip", ""));
-        Future<String> callable = zip.actAsync(new DownloaderCallable(destination.getRemote()));
-
-        return callable.get();
+    @SuppressFBWarnings
+    private static String unzipFile(FilePath zip) throws IOException, InterruptedException {
+        FilePath destination = zip.getParent();
+        zip.unzip(destination);
+        FilePath binaryPath = destination.child("inspector-sbomgen");
+        binaryPath.chmod(0755);
+        return binaryPath.getRemote();
     }
 }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,8 +1,6 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URL;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -29,7 +29,7 @@ public class SbomgenDownloader {
 
         String osArch = System.getProperty("os.arch").toLowerCase();
         logger.println("Detected OS Architecture: " + osArch);
-        if (osArch.contains("arm64") || osArch.contains("aarch64"))
+        if (osArch.contains("arm64") || osArch.contains("aarch64")) {
             architecture = "arm64";
         } else if (!osArch.contains("amd64") && !osArch.contains("x86_64")) {
             throw new UnsupportedOperationException("Unsupported architecture: " + osArch);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -7,6 +7,8 @@ import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder.logger;
+
 public class SbomgenDownloader {
     private static final String BASE_URL = "https://amazon-inspector-" +
             "sbomgen.s3.amazonaws.com/latest/linux/%s/inspector-sbomgen.zip";
@@ -18,7 +20,7 @@ public class SbomgenDownloader {
 
     private static String getUrl() {
         String osName = System.getProperty("os.name").toLowerCase();
-        System.out.println("Detected OS Name: " + osName);
+        logger.println("Detected OS Name: " + osName);
         if (!osName.contains("linux")) {
             throw new UnsupportedOperationException("Unsupported OS: " + osName);
         }
@@ -26,8 +28,8 @@ public class SbomgenDownloader {
         String architecture = "amd64";
 
         String osArch = System.getProperty("os.arch").toLowerCase();
-        System.out.println("Detected OS Architecture: " + osArch);
-        if (osArch.contains("arm64") || osArch.contains("aarch64")) {
+        logger.println("Detected OS Architecture: " + osArch);
+        if (osArch.contains("arm64") || osArch.contains("aarch64"))
             architecture = "arm64";
         } else if (!osArch.contains("amd64") && !osArch.contains("x86_64")) {
             throw new UnsupportedOperationException("Unsupported architecture: " + osArch);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -18,7 +18,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.processSbomgenOutput;
 
@@ -32,6 +34,8 @@ public class SbomgenRunner {
     public String dockerUsername;
     @Setter
     public String dockerPassword;
+    @Setter
+    private String sbomgenSkipFiles;
 
     public SbomgenRunner(Launcher launcher, String sbomgenPath, String archivePath, String dockerUsername) {
         this.sbomgenPath = sbomgenPath;
@@ -57,6 +61,9 @@ public class SbomgenRunner {
         this.launcher = launcher;
     }
 
+    public SbomgenRunner(Launcher launcher, String activeSbomgenPath, String activeArchiveType, String archivePath, String username, String plainText, String sbomgenSkipFiles) {
+    }
+
     public String run() throws Exception {
         return runSbomgen(sbomgenPath, archivePath);
     }
@@ -79,6 +86,21 @@ public class SbomgenRunner {
         SbomgenUtils.runCommand(new String[]{"chmod", "+x", sbomgenFilePath.getRemote()}, launcher, environment);
 
         AmazonInspectorBuilder.logger.println("Running command...");
+
+        String skipFilesArg = "";
+        List<String> validPatterns = null;
+        if (sbomgenSkipFiles != null && !sbomgenSkipFiles.trim().isEmpty()) {
+            String[] skipFilesArray = sbomgenSkipFiles.split("\\r?\\n");
+            validPatterns = Arrays.stream(skipFilesArray)
+                    .map(String::trim)
+                    .filter(pattern -> !pattern.isEmpty())
+                    .collect(Collectors.toList());
+            if (!validPatterns.isEmpty()) {
+                String skipFilesJoined = String.join(",", validPatterns);
+                skipFilesArg = "--skip-files " + skipFilesJoined;
+                AmazonInspectorBuilder.logger.println("DEBUG: --skip-files argument: " + skipFilesArg);
+            }
+        }
         String option = "--image";
         if (!archiveType.equals("container")) {
             option = "--path";
@@ -87,8 +109,18 @@ public class SbomgenRunner {
                 sbomgenFilePath.getRemote(), archiveType, option, archivePath
         };
         AmazonInspectorBuilder.logger.println(Arrays.toString(commandList));
-        String output = SbomgenUtils.runCommand(commandList, launcher, environment);
 
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        args.add(sbomgenFilePath.getRemote());
+        args.add(archiveType);
+        args.add(option);
+        args.add(archivePath);
+        if (!skipFilesArg.isEmpty()) {
+            args.add("--skip-files");
+            args.add(String.join(",", validPatterns));
+        }
+        AmazonInspectorBuilder.logger.println("Executing SBOMGen with command: " + args);
+        String output = SbomgenUtils.runCommand(args.toCommandArray(), launcher, environment);
         return SbomgenUtils.processSbomgenOutput(output);
     }
 

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,23 +30,6 @@
         }
     </style>
 
-    <f:entry field="sbomgenSelectionWrapper" title="Inspector-sbomgen Installation Method"></f:entry>
-
-    <f:radioBlock title="Automatic" name="sbomgenSelection" checked="${instance.isSource('automatic')}" value="automatic">
-        <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="${instance.isOs('linuxAmd64')}">
-        </f:radioBlock>
-        <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="${instance.isOs('linuxArm64')}">
-        </f:radioBlock>
-    </f:radioBlock>
-
-    <f:radioBlock title="Manual" name="sbomgenSelection" checked="${instance.isSource('manual')}"
-                  value="manual">
-        <p>Path to inspector-sbomgen</p>
-        <f:entry field="sbomgenPath">
-            <f:textbox placeholder="/Users/user/Downloads/inspector-sbomgen"/>
-        </f:entry>
-    </f:radioBlock>
-
     <p class="required-field">Image Id</p>
     <f:entry field="archivePath">
         <f:textbox placeholder="/Users/user/Downloads/alpine.tar or alpine:latest" />

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,6 +30,17 @@
         }
     </style>
 
+    <f:entry field="sbomgenSelectionWrapper" title="Inspector-sbomgen Installation Method">
+        <f:radioBlock title="Automatic" name="sbomgenSelection" checked="${instance.isSource('automatic')}" value="automatic">
+        </f:radioBlock>
+        <f:radioBlock title="Manual" name="sbomgenSelection" checked="${instance.isSource('manual')}" value="manual">
+            <p>Path to inspector-sbomgen</p>
+            <f:entry field="sbomgenPath">
+                <f:textbox placeholder="/Users/user/Downloads/inspector-sbomgen"/>
+            </f:entry>
+        </f:radioBlock>
+    </f:entry>
+
     <p class="required-field">Image Id</p>
     <f:entry field="archivePath">
         <f:textbox placeholder="/Users/user/Downloads/alpine.tar or alpine:latest" />

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -41,6 +41,10 @@
         </f:radioBlock>
     </f:entry>
 
+    <f:entry field="sbomgenSkipFiles" title="SBOMGen Skip Files" description="Specify file patterns to exclude from SBOM generation. Enter one pattern per line, e.g., *.tmp, build/, node_modules/">
+        <f:textarea name="sbomgenSkipFiles"/>
+    </f:entry>
+
     <p class="required-field">Image Id</p>
     <f:entry field="archivePath">
         <f:textbox placeholder="/Users/user/Downloads/alpine.tar or alpine:latest" />


### PR DESCRIPTION
Summary:
Jenkins extended to support the --skip-files argument in inspector-sbomgen. Customers should be able to specify this in both the UI and declarative mode.