### PR TITLE
Fix: Add agent-aware architecture detection support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.12</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.1</version>
+            <version>2.19.2</version>
         </dependency>
 
         <dependency>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.18.3-402.v74c4eb_f122b_2</version>
+            <version>2.19.2-408.v18248a_324cfe</version>
         </dependency>
 
         <dependency>
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.11.2</version>
+            <version>5.9</version>
         </dependency>
 
         <dependency>
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.18.0</version>
+            <version>1.19.0</version>
         </dependency>
 
         <dependency>
@@ -250,7 +250,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.3</version>
                 <configuration>
                     <excludes>
                         <exclude>**InjectedTest</exclude>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -191,7 +191,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             String activeSbomgenPath;
             if ("automatic".equalsIgnoreCase(sbomgenSelection)) {
                 logger.println("Automatic SBOMGen selected, downloading using default settings...");
-                activeSbomgenPath = SbomgenDownloader.getBinary(workspace);
+                activeSbomgenPath = SbomgenDownloader.getBinary(workspace, env, launcher);
             } else if ("manual".equalsIgnoreCase(sbomgenSelection)) {
                 if (sbomgenPath == null || sbomgenPath.isEmpty()) {
                     throw new IllegalArgumentException("Manual SBOMGen selected but no path provided.");
@@ -204,7 +204,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 activeSbomgenPath = sbomgenPath;
             } else {
                 logger.println("Invalid SBOMGen selection. Defaulting to Automatic.");
-                activeSbomgenPath = SbomgenDownloader.getBinary(workspace);
+                activeSbomgenPath = SbomgenDownloader.getBinary(workspace, env, launcher);
             }
 
             StandardUsernamePasswordCredentials credential = null;
@@ -218,10 +218,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             String skipfiles = (sbomgenSkipFiles != null) ? sbomgenSkipFiles : "";
             String sbom;
             if (credential != null) {
-                sbom = new SbomgenRunner(launcher, activeSbomgenPath, activeArchiveType, archivePath, credential.getUsername(),
+                sbom = new SbomgenRunner(launcher, workspace, activeSbomgenPath, activeArchiveType, archivePath, credential.getUsername(),
                         credential.getPassword().getPlainText(),skipfiles).run();
             } else {
-                sbom = new SbomgenRunner(launcher, activeSbomgenPath, activeArchiveType, archivePath, null, null, skipfiles).run();
+                sbom = new SbomgenRunner(launcher, workspace, activeSbomgenPath, activeArchiveType, archivePath, null, null, skipfiles).run();
             }
 
             JsonElement metadata = JsonParser.parseString(sbom).getAsJsonObject().get("metadata");

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -12,13 +12,13 @@ import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspec
 public class SbomgenDownloader {
     private static final String BASE_URL = "https://amazon-inspector-" +
             "sbomgen.s3.amazonaws.com/latest/linux/%s/inspector-sbomgen.zip";
-    public static String getBinary(FilePath workspace) throws IOException, InterruptedException, ExecutionException {
-        String url = getUrl();
+    public static String getBinary(FilePath workspace, hudson.EnvVars env, hudson.Launcher launcher) throws IOException, InterruptedException, ExecutionException {
+        String url = getUrl(workspace, env, launcher);
         FilePath zipPath = downloadFile(url, workspace);
         return unzipFile(zipPath);
     }
 
-    private static String getUrl() {
+    public static String getUrl(FilePath workspace, hudson.EnvVars env, hudson.Launcher launcher) throws IOException, InterruptedException {
         String osName = System.getProperty("os.name").toLowerCase();
         logger.println("Detected OS Name: " + osName);
         if (!osName.contains("linux")) {
@@ -26,9 +26,29 @@ public class SbomgenDownloader {
         }
 
         String architecture = "amd64";
-
-        String osArch = System.getProperty("os.arch").toLowerCase();
-        logger.println("Detected OS Architecture: " + osArch);
+        String osArch = null;
+        
+        // Try to get architecture from agent using launcher (same pattern as SbomgenRunner)
+        if (launcher != null) {
+            try {
+                java.util.Map<String, String> environment = new java.util.HashMap<>();
+                String output = SbomgenUtils.runCommand(new String[]{"uname", "-m"}, launcher, environment);
+                if (output != null && !output.trim().isEmpty()) {
+                    osArch = output.trim();
+                    logger.println("Detected OS Architecture (from agent): " + osArch);
+                }
+            } catch (Exception e) {
+                logger.println("Failed to detect architecture from agent: " + e.getMessage());
+            }
+        }
+        
+        // Fallback to System.getProperty if agent detection failed
+        if (osArch == null || osArch.trim().isEmpty()) {
+            osArch = System.getProperty("os.arch").toLowerCase();
+            logger.println("Detected OS Architecture (fallback from master): " + osArch);
+        }
+        
+        osArch = osArch.toLowerCase().trim();
         if (osArch.contains("arm64") || osArch.contains("aarch64")) {
             architecture = "arm64";
         } else if (!osArch.contains("amd64") && !osArch.contains("x86_64")) {

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -20,6 +20,7 @@ public class SbomgenRunner {
     public String archiveType;
     public String archivePath;
     public Launcher launcher;
+    public FilePath workspace;
 
     @Setter
     public String dockerUsername;
@@ -29,7 +30,7 @@ public class SbomgenRunner {
 
     private final String sbomgenSkipFiles;
 
-    public SbomgenRunner(Launcher launcher, String sbomgenPath, String activeArchiveType,
+    public SbomgenRunner(Launcher launcher, FilePath workspace, String sbomgenPath, String activeArchiveType,
                          String archivePath, String dockerUsername, String dockerPassword,
                          String sbomgenSkipFiles) {
         this.sbomgenPath = sbomgenPath;
@@ -38,6 +39,7 @@ public class SbomgenRunner {
         this.dockerUsername = dockerUsername;
         this.dockerPassword = dockerPassword;
         this.launcher = launcher;
+        this.workspace = workspace;
         this.sbomgenSkipFiles = sbomgenSkipFiles;
     }
 
@@ -46,7 +48,12 @@ public class SbomgenRunner {
     }
 
     private String runSbomgen(String sbomgenPath, String archivePath) throws Exception {
-        FilePath sbomgenFilePath = new FilePath(new File(sbomgenPath));
+        FilePath sbomgenFilePath;
+        if (workspace.getChannel() != null) {
+            sbomgenFilePath = new FilePath(workspace.getChannel(), sbomgenPath);
+        } else {
+            sbomgenFilePath = new FilePath(new File(sbomgenPath));
+        }
 
         if (!isValidPath(sbomgenFilePath.getRemote())) {
             throw new IllegalArgumentException("Invalid sbomgen path: " + sbomgenPath);

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
@@ -1,15 +1,19 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SbomgenRunnerTest {
 
     @Test
     public void testIsValidPath() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
         
         // Valid paths (matching regex: ^[a-zA-Z0-9/._\-: ]+$)
         assertTrue(runner.isValidPath("alpine:latest"));
@@ -35,7 +39,7 @@ public class SbomgenRunnerTest {
 
     @Test
     public void testIsValidPathEdgeCases() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
         
         // Edge cases that should be invalid
         assertFalse(runner.isValidPath(""));
@@ -53,7 +57,34 @@ public class SbomgenRunnerTest {
 
     @Test(expected = NullPointerException.class)
     public void testIsValidPathWithNull() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
         runner.isValidPath(null);
+    }
+
+    @Test
+    public void testWorkspaceChannelDetectionForRemoteAgent() throws Exception {
+        FilePath mockWorkspace = mock(FilePath.class);
+        VirtualChannel mockChannel = mock(VirtualChannel.class);
+        
+        when(mockWorkspace.getChannel()).thenReturn(mockChannel);
+        
+        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null);
+        
+        // Verify the runner correctly identifies remote agent scenario
+        assertTrue("Should detect remote agent when workspace has channel", 
+                   runner.workspace.getChannel() != null);
+    }
+
+    @Test
+    public void testWorkspaceChannelDetectionForLocalExecution() throws Exception {
+        FilePath mockWorkspace = mock(FilePath.class);
+        
+        when(mockWorkspace.getChannel()).thenReturn(null);
+        
+        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null);
+        
+        // Verify the runner correctly identifies local execution scenario
+        assertTrue("Should detect local execution when workspace has no channel", 
+                   runner.workspace.getChannel() == null);
     }
 }


### PR DESCRIPTION
## Problem
The Amazon Inspector Jenkins plugin was downloading AMD64 binaries regardless of agent architecture, causing "cannot execute binary file" errors on ARM64 agents.

## Solution  
Implemented agent-aware architecture detection that executes `uname -m` on the build agent (not master) to determine the correct binary architecture.

## Changes
- **SbomgenDownloader.java**: Added agent architecture detection via launcher command execution
- **AmazonInspectorBuilder.java**: Updated method calls to pass launcher parameter
- **SbomgenRunner.java**: Added workspace parameter for agent communication
- **SbomgenRunnerTest.java**: Updated test constructor calls
- **pom.xml**: Build configuration updates
- **Backward Compatible**: Falls back to master architecture detection if agent detection fails

## Testing
✅ Pipeline mode on ARM64 agent → Downloads arm64 binary  
✅ Freestyle UI on ARM64 agent → Downloads arm64 binary  
✅ Freestyle UI on AMD64 master → Downloads amd64 binary

<img width="1259" height="1222" alt="image (10)" src="https://github.com/user-attachments/assets/990d3167-d9c3-43fa-9e63-33a700bb3b3a" />
<img width="1313" height="871" alt="image (11)" src="https://github.com/user-attachments/assets/13a27cb6-0c42-4f5e-9044-47a500c94755" />
<img width="1313" height="871" alt="image (12)" src="https://github.com/user-attachments/assets/37bf9d05-c48d-4a80-965b-fdb6638aac58" />

