### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/inspector-scan.yaml
+++ b/.github/workflows/inspector-scan.yaml
@@ -18,7 +18,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
      - name: Checkout repository
-       uses: actions/checkout@v4
+       uses: actions/checkout@v5
 
      - name: Scan project with Inspector
        id: inspector

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.2</version>
+            <version>2.20.0</version>
         </dependency>
 
         <dependency>
@@ -92,13 +92,13 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.11.0</version>
+            <version>2.13.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-            <version>2.39.0</version>
+            <version>2.41.0</version>
         </dependency>
 
         <dependency>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>350.v3b_30f09f2363</version>
+            <version>353.v261ea_40a_80fb_</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update dependencies to latest versions

- Update jackson-databind from 2.19.2 to 2.20.0
- Update gson from 2.11.0 to 2.13.1
- Update error_prone_annotations from 2.39.0 to 2.41.0
- Update structs plugin from 350.v3b_30f09f2363 to 353.v261ea_40a_80fb_
- Update GitHub Actions checkout from v4 to v5
- Keep credentials plugin at 1415.v831096eb_5534 due to commons-lang3 dependency conflict

All changes have been tested and build successfully.

<img width="566" height="92" alt="image" src="https://github.com/user-attachments/assets/ecaee826-f4b4-41d6-bbd9-a8af95e56070" />

