### PR TITLE
Add license collection feature for Bomerman v1.8.0+

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -29,10 +29,11 @@ public class SbomgenRunner {
     public String dockerPassword;
 
     private final String sbomgenSkipFiles;
+    private final boolean isLicenseCollectionEnabled;
 
     public SbomgenRunner(Launcher launcher, FilePath workspace, String sbomgenPath, String activeArchiveType,
                          String archivePath, String dockerUsername, String dockerPassword,
-                         String sbomgenSkipFiles) {
+                         String sbomgenSkipFiles, boolean isLicenseCollectionEnabled) {
         this.sbomgenPath = sbomgenPath;
         this.archivePath = archivePath;
         this.archiveType = activeArchiveType;
@@ -41,6 +42,7 @@ public class SbomgenRunner {
         this.launcher = launcher;
         this.workspace = workspace;
         this.sbomgenSkipFiles = sbomgenSkipFiles;
+        this.isLicenseCollectionEnabled = isLicenseCollectionEnabled;
     }
 
     public String run() throws Exception {
@@ -103,6 +105,16 @@ public class SbomgenRunner {
                         skipFilesJoined);
                 AmazonInspectorBuilder.logger.println(Arrays.toString(baseCommandList));
             }
+        }
+
+        if (isLicenseCollectionEnabled) {
+            String[] extendedCommandList = Arrays.copyOf(baseCommandList,
+                    baseCommandList.length + 1);
+            extendedCommandList[extendedCommandList.length - 1] = "--collect-licenses";
+            baseCommandList = extendedCommandList;
+
+            AmazonInspectorBuilder.logger.println("License collection enabled, adding --collect-licenses flag");
+            AmazonInspectorBuilder.logger.println(Arrays.toString(baseCommandList));
         }
 
         String output = SbomgenUtils.runCommand(baseCommandList, launcher, environment);

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -180,4 +180,12 @@
             <f:textarea placeholder="CVE-2023-9999, CVE-2024-0001" rows="3" />
         </f:entry>
     </div>
+    
+    <f:entry field="isLicenseCollectionEnabled">
+        <f:checkbox id="isLicenseCollectionEnabled"
+                    class="bold"
+                    checked="${instance.isLicenseCollectionEnabled}"
+                    title="Enable license collection"
+                    tooltip="Collect license information for packages in the SBOM. Requires Bomerman v1.8.0 or greater." />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-isLicenseCollectionEnabled.html
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-isLicenseCollectionEnabled.html
@@ -1,0 +1,7 @@
+<div>
+    Collects license information for packages in your SBOM artifact.
+    <br/><br/>
+    <strong>Requirements:</strong> Bomerman v1.8.0+ required.
+    <br/><br/>
+    License data will be included in the SBOM output for compliance and reporting purposes.
+</div>

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderTest.java
@@ -26,6 +26,7 @@ public class AmazonInspectorBuilderTest {
             true, 
             "CVE-2024-9999",
             true,
+            true,
             true
         );
 
@@ -33,6 +34,7 @@ public class AmazonInspectorBuilderTest {
         assertTrue(builder.getIsEpssThresholdEnabled());
         assertTrue(builder.getIsSuppressedCveEnabled());
         assertTrue(builder.getIsAutoFailCveEnabled());
+        assertTrue(builder.getIsLicenseCollectionEnabled());
         assertEquals("CVE-2023-1234,CVE-2023-5678", builder.getSuppressedCveList());
         assertEquals("CVE-2024-9999", builder.getAutoFailCveList());
         assertEquals(Double.valueOf(0.7), builder.getEpssThreshold());
@@ -60,6 +62,7 @@ public class AmazonInspectorBuilderTest {
             false, 
             false, 
             "",
+            false,
             null,
             null
         );
@@ -68,6 +71,7 @@ public class AmazonInspectorBuilderTest {
         assertFalse(builder.getIsEpssThresholdEnabled());
         assertFalse(builder.getIsSuppressedCveEnabled());
         assertFalse(builder.getIsAutoFailCveEnabled());
+        assertFalse(builder.getIsLicenseCollectionEnabled());
         assertEquals("", builder.getSuppressedCveList());
         assertEquals("", builder.getAutoFailCveList());
         assertEquals(Double.valueOf(0.5), builder.getEpssThreshold());
@@ -99,6 +103,7 @@ public class AmazonInspectorBuilderTest {
             true, 
             true, 
             "CVE-2023-2222",
+            false,
             null,
             null
         );
@@ -130,6 +135,7 @@ public class AmazonInspectorBuilderTest {
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", null, "",
             false, false, "",
+            false,
             null,
             null
         );
@@ -143,6 +149,7 @@ public class AmazonInspectorBuilderTest {
             "", "", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.0, "",
             false, false, "",
+            false,
             null,
             null
         );
@@ -160,6 +167,7 @@ public class AmazonInspectorBuilderTest {
             "automatic", "", Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
             "", "", 1.0, "",
             true, true, "",
+            false,
             null,
             null
         );
@@ -178,6 +186,7 @@ public class AmazonInspectorBuilderTest {
             "automatic", "", 0, 0, 0, 0,
             "", "", 0.0, "",
             true, true, "",
+            false,
             null,
             null
         );
@@ -197,6 +206,7 @@ public class AmazonInspectorBuilderTest {
             "manual", "/custom/path/sbomgen", 1, 5, 10, 50,
             "oidc-123", "*.tmp,*.log", 0.85, "CVE-2023-1111,CVE-2023-2222",
             true, true, "CVE-2023-9999",
+            true,
             true,
             true
         );
@@ -220,6 +230,7 @@ public class AmazonInspectorBuilderTest {
             "CVE-2023-1234,CVE-2024-5678,CVE-2022-9999,CVE-2025-123456",
             true, true,
             "CVE-2023-0001,CVE-2024-0002",
+            false,
             null,
             null
         );
@@ -236,6 +247,7 @@ public class AmazonInspectorBuilderTest {
             "CVE-2023-1234",
             true, true,
             "CVE-2024-9999",
+            false,
             null,
             null
         );
@@ -250,6 +262,7 @@ public class AmazonInspectorBuilderTest {
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", null, "",
             false, false, "",
+            false,
             null,
             null
         );
@@ -259,6 +272,7 @@ public class AmazonInspectorBuilderTest {
             "test", "test", "archive", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", null, "",
             false, false, "",
+            false,
             null,
             null
         );
@@ -274,6 +288,7 @@ public class AmazonInspectorBuilderTest {
                 "test", "test", "container", false, "", region, "", "", "",
                 "automatic", "", 0, 0, 0, 0, "", "", null, "",
                 false, false, "",
+                false,
                 null,
                 null
             );
@@ -290,6 +305,7 @@ public class AmazonInspectorBuilderTest {
                 "test", "test", "container", false, "", "us-east-1", "", "", "",
                 selection, "", 0, 0, 0, 0, "", "", null, "",
                 false, false, "",
+                false,
                 null,
                 null
             );
@@ -309,6 +325,7 @@ public class AmazonInspectorBuilderTest {
                             "test", "test", "container", false, "", "us-east-1", "", "", "",
                             "automatic", "", 0, 0, 0, 0, "", "", 0.5, "",
                             suppressFlag, autoFailFlag, "",
+                            false,
                             severityFlag,
                             epssFlag
                         );
@@ -343,6 +360,7 @@ public class AmazonInspectorBuilderTest {
             null, 
             "",
             false, false, "",
+            false,
             null,
             null
         );
@@ -358,6 +376,7 @@ public class AmazonInspectorBuilderTest {
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.5, "",
             false, false, "",
+            false,
             true, true
         );
 

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
@@ -13,7 +13,7 @@ public class SbomgenRunnerTest {
 
     @Test
     public void testIsValidPath() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
         
         // Valid paths (matching regex: ^[a-zA-Z0-9/._\-: ]+$)
         assertTrue(runner.isValidPath("alpine:latest"));
@@ -39,7 +39,7 @@ public class SbomgenRunnerTest {
 
     @Test
     public void testIsValidPathEdgeCases() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
         
         // Edge cases that should be invalid
         assertFalse(runner.isValidPath(""));
@@ -57,7 +57,7 @@ public class SbomgenRunnerTest {
 
     @Test(expected = NullPointerException.class)
     public void testIsValidPathWithNull() {
-        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
         runner.isValidPath(null);
     }
 
@@ -68,7 +68,7 @@ public class SbomgenRunnerTest {
         
         when(mockWorkspace.getChannel()).thenReturn(mockChannel);
         
-        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
         
         // Verify the runner correctly identifies remote agent scenario
         assertTrue("Should detect remote agent when workspace has channel", 
@@ -81,7 +81,7 @@ public class SbomgenRunnerTest {
         
         when(mockWorkspace.getChannel()).thenReturn(null);
         
-        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null);
+        SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
         
         // Verify the runner correctly identifies local execution scenario
         assertTrue("Should detect local execution when workspace has no channel", 


### PR DESCRIPTION
## Add License Collection Feature

Enables license data collection in SBOM artifacts for customers using Bomerman v1.8.0+.

### Changes
- Added `isLicenseCollectionEnabled` checkbox to Jenkins UI with help button explaining v1.8.0+ requirement
- Modified `AmazonInspectorBuilder.java` and `SbomgenRunner.java` to pass `--collect-licenses` flag to Bomerman
- Updated test constructors to support new parameter
- All 59 tests passing

<img width="1605" height="170" alt="image" src="https://github.com/user-attachments/assets/daacc6a9-5bfc-4f6a-ab09-26312531f334" />
<img width="1605" height="370" alt="image" src="https://github.com/user-attachments/assets/bc06f094-230a-49bc-b9e6-9e53661cb821" />
<img width="1605" height="370" alt="image" src="https://github.com/user-attachments/assets/3a639e74-071b-49fd-b514-cf0f0a788457" />
<img width="1605" height="1108" alt="image" src="https://github.com/user-attachments/assets/9e58d471-1dd6-4e14-b802-d3f67b590b97" />
