### PR TITLE
Update dependabot recommended dependencies

### DIFF
--- a/.github/workflows/inspector-scan.yaml
+++ b/.github/workflows/inspector-scan.yaml
@@ -10,7 +10,7 @@ jobs:
 
    steps:
      - name: Configure AWS credentials
-       uses: aws-actions/configure-aws-credentials@v4
+       uses: aws-actions/configure-aws-credentials@v5
        with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/pom.xml
+++ b/pom.xml
@@ -78,21 +78,21 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>1.18.42</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.17.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Dependency Updates (October 8, 2025)

Updates several dependencies to their latest versions based on dependabot recommendations.

### ✅ Updated Dependencies:
- **lombok**: 1.18.38 → 1.18.42
- **mockito-core**: 5.17.0 → 5.20.0 
- **gson**: 2.13.1 → 2.13.2
- **aws-actions/configure-aws-credentials**: v4 → v5



### Testing:
- ✅ All updates compile successfully
- ✅ Full Maven package build completes without errors
- ✅ No breaking changes detected

### Notes:
This addresses 4 out of 6 pending dependabot PRs.

