### PR TITLE
fix: EPSS threshold reads scan response instead of inventory SBOM (#169)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.42.4</version>
+                <version>2.42.25</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -54,19 +54,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.20.1</version>
+            <version>2.21.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>209.vc1e7c6295cff</version>
+            <version>199.v9f8e1f741799</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.21.0-428.v87fd3700d79d</version>
+            <version>2.19.2-408.v18248a_324cfe</version>
         </dependency>
 
         <dependency>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.42</version>
+            <version>1.18.44</version>
             <scope>provided</scope>
         </dependency>
 
@@ -120,6 +120,21 @@
             <version>5.12.0</version>
         </dependency>
 
+        <!-- opencsv 5.12 requires commons-beanutils 1.11.0; parent POM manages
+             1.9.4. Exclude commons-logging because the 1.3.5 it pulls is banned
+             by the parent's BannedDependencies rule. -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
@@ -154,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>353.v261ea_40a_80fb_</version>
+            <version>362.va_b_695ef4fdf9</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -12,7 +12,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
@@ -707,7 +706,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             
             if (isEpssThresholdEnabled && epssThreshold != null) {
                 listener.getLogger().println("EPSS Threshold set to: " + epssThreshold);
-                boolean cvesExceedThreshold = assessCVEsAgainstEPSS(build, workspace, listener, epssThreshold, sbomWorkspacePath);
+                boolean cvesExceedThreshold = assessCVEsAgainstEPSS(listener, epssThreshold, sbomData);
                 if (cvesExceedThreshold) {
                     doesBuildPass = false;
                 }
@@ -738,86 +737,66 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         }
     }
 
-    private boolean assessCVEsAgainstEPSS(Run<?, ?> build, FilePath workspace, TaskListener listener, Double epssThreshold, String sbomPath)
-            throws IOException, InterruptedException {
-        FilePath sbomFile = workspace.child(sbomPath);
-        if (!sbomFile.exists()) {
-            listener.getLogger().println("SBOM file not found at: " + sbomFile.getRemote());
-            return true;
+    private boolean assessCVEsAgainstEPSS(TaskListener listener, Double epssThreshold, SbomData sbomData) {
+        List<Vulnerability> vulnerabilities = sbomData.getSbom().getVulnerabilities();
+        if (vulnerabilities == null || vulnerabilities.isEmpty()) {
+            listener.getLogger().println("No vulnerabilities found in the scan response.");
+            return false;
         }
-        try {
-            String sbomContent = sbomFile.readToString();
-            listener.getLogger().println("SBOM file read successfully.");
-            Gson gson = new Gson();
-            Sbom sbom = gson.fromJson(sbomContent, Sbom.class);
-            listener.getLogger().println("SBOM JSON parsed successfully.");
-            List<Vulnerability> vulnerabilities = sbom.getVulnerabilities();
-            if (vulnerabilities == null || vulnerabilities.isEmpty()) {
-                listener.getLogger().println("No vulnerabilities found in the SBOM.");
-                return false;
+
+        Set<String> suppressedCveSet = new HashSet<>();
+        if (isSuppressedCveEnabled && suppressedCveList != null && !suppressedCveList.trim().isEmpty()) {
+            String[] cveArray = suppressedCveList.split("[,\\n\\r]+");
+            for (String cve : cveArray) {
+                suppressedCveSet.add(cve.trim().toUpperCase());
             }
-            
-            Set<String> suppressedCveSet = new HashSet<>();
-            if (isSuppressedCveEnabled && suppressedCveList != null && !suppressedCveList.trim().isEmpty()) {
-                String[] cveArray = suppressedCveList.split("[,\\n\\r]+");
-                for (String cve : cveArray) {
-                    suppressedCveSet.add(cve.trim().toUpperCase());
-                }
-                listener.getLogger().println("Suppressing " + suppressedCveSet.size() + " CVEs from EPSS assessment: " + suppressedCveSet);
-            }
-            
-            listener.getLogger().println("Starting EPSS assessment for vulnerabilities...");
-            boolean exceedsThreshold = false;
-            Map<String, Double> exceedingCVEsMap = new HashMap<>();
-            int suppressedCount = 0;
-            
-            for (Vulnerability vulnerability : vulnerabilities) {
-                String cveId = vulnerability.getId();
-                Double epssScore = vulnerability.getEpssScore();
-                
-                // Skip suppressed CVEs
-                if (suppressedCveSet.contains(cveId.toUpperCase())) {
-                    suppressedCount++;
-                    continue;
-                }
-                
-                if (epssScore == null) {
-                    continue;
-                }
-                if (epssScore >= epssThreshold) {
-                    exceedsThreshold = true;
-                    exceedingCVEsMap.put(cveId, epssScore);
-                }
-            }
-            
-            if (suppressedCount > 0) {
-                listener.getLogger().println("Suppressed " + suppressedCount + " CVEs from EPSS assessment.");
-            }
-            
-            if (exceedsThreshold) {
-                listener.getLogger().println("The following CVEs exceed the EPSS threshold of " + epssThreshold + ":");
-                int count = 0;
-                for (Map.Entry<String, Double> entry : exceedingCVEsMap.entrySet()) {
-                    if (count < MAX_EPSS_CVES_CONSOLE) {
-                        listener.getLogger().println(String.format("  - %s (EPSS: %.3f)", entry.getKey(), entry.getValue()));
-                        count++;
-                    } else {
-                        listener.getLogger().println("  ... and " + (exceedingCVEsMap.size() - count) + " more EPSS breaches (check assessment file for complete list)");
-                        break;
-                    }
-                }
-                listener.getLogger().println("Failing the build due to EPSS threshold breach.");
-            } else {
-                listener.getLogger().println("All assessed CVEs are within the EPSS threshold of " + epssThreshold + ".");
-            }
-            return exceedsThreshold;
-        } catch (JsonParseException e) {
-            listener.getLogger().println("Invalid JSON structure in SBOM file: " + e.getMessage());
-            return true;
-        } catch (IOException e) {
-            listener.getLogger().println("Error reading SBOM file: " + e.getMessage());
-            return true;
+            listener.getLogger().println("Suppressing " + suppressedCveSet.size() + " CVEs from EPSS assessment: " + suppressedCveSet);
         }
+
+        listener.getLogger().println("Starting EPSS assessment for vulnerabilities...");
+        boolean exceedsThreshold = false;
+        Map<String, Double> exceedingCVEsMap = new HashMap<>();
+        int suppressedCount = 0;
+
+        for (Vulnerability vulnerability : vulnerabilities) {
+            String cveId = vulnerability.getId();
+            Double epssScore = vulnerability.getEpssScore();
+
+            if (suppressedCveSet.contains(cveId.toUpperCase())) {
+                suppressedCount++;
+                continue;
+            }
+
+            if (epssScore == null) {
+                continue;
+            }
+            if (epssScore >= epssThreshold) {
+                exceedsThreshold = true;
+                exceedingCVEsMap.put(cveId, epssScore);
+            }
+        }
+
+        if (suppressedCount > 0) {
+            listener.getLogger().println("Suppressed " + suppressedCount + " CVEs from EPSS assessment.");
+        }
+
+        if (exceedsThreshold) {
+            listener.getLogger().println("The following CVEs exceed the EPSS threshold of " + epssThreshold + ":");
+            int count = 0;
+            for (Map.Entry<String, Double> entry : exceedingCVEsMap.entrySet()) {
+                if (count < MAX_EPSS_CVES_CONSOLE) {
+                    listener.getLogger().println(String.format("  - %s (EPSS: %.3f)", entry.getKey(), entry.getValue()));
+                    count++;
+                } else {
+                    listener.getLogger().println("  ... and " + (exceedingCVEsMap.size() - count) + " more EPSS breaches (check assessment file for complete list)");
+                    break;
+                }
+            }
+            listener.getLogger().println("Failing the build due to EPSS threshold breach.");
+        } else {
+            listener.getLogger().println("All assessed CVEs are within the EPSS threshold of " + epssThreshold + ".");
+        }
+        return exceedsThreshold;
     }
 
     private String getOidcToken(IdTokenStringCredentials oidcStr, IdTokenFileCredentials oidcFile) throws IOException {

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderEpssTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderEpssTest.java
@@ -1,0 +1,131 @@
+package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
+
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Sbom;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Rating;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Source;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
+import hudson.model.TaskListener;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AmazonInspectorBuilderEpssTest {
+
+    private TaskListener listener;
+    private Method assessMethod;
+
+    @Before
+    public void setUp() throws Exception {
+        listener = mock(TaskListener.class);
+        when(listener.getLogger()).thenReturn(new PrintStream(new ByteArrayOutputStream()));
+
+        assessMethod = AmazonInspectorBuilder.class.getDeclaredMethod(
+                "assessCVEsAgainstEPSS", TaskListener.class, Double.class, SbomData.class);
+        assessMethod.setAccessible(true);
+    }
+
+    @Test
+    public void emptyVulnerabilitiesReturnsFalse() throws Exception {
+        assertFalse(invoke(builder(false, ""), 0.5, sbomData(Collections.emptyList())));
+    }
+
+    @Test
+    public void nullVulnerabilitiesReturnsFalse() throws Exception {
+        assertFalse(invoke(builder(false, ""), 0.5, sbomData(null)));
+    }
+
+    @Test
+    public void vulnAboveThresholdReturnsTrue() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.8));
+        assertTrue(invoke(builder(false, ""), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void vulnBelowThresholdReturnsFalse() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.1));
+        assertFalse(invoke(builder(false, ""), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void vulnEqualToThresholdReturnsTrue() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.5));
+        assertTrue(invoke(builder(false, ""), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void nullEpssScoreIsSkipped() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(noEpssVuln("CVE-1"));
+        assertFalse(invoke(builder(false, ""), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void suppressedCveAboveThresholdIsSkippedWhenSuppressionEnabled() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.9));
+        assertFalse(invoke(builder(true, "CVE-1"), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void suppressedCveAboveThresholdIsCountedWhenSuppressionDisabled() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.9));
+        assertTrue(invoke(builder(false, "CVE-1"), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void mixOfSuppressedAndBreachingCves() throws Exception {
+        List<Vulnerability> vulns = Arrays.asList(
+                epssVuln("CVE-1", 0.9),
+                epssVuln("CVE-2", 0.8),
+                epssVuln("CVE-3", 0.1));
+        assertTrue(invoke(builder(true, "CVE-1"), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void allSuppressedReturnsFalseEvenWhenAboveThreshold() throws Exception {
+        List<Vulnerability> vulns = Arrays.asList(
+                epssVuln("CVE-1", 0.9),
+                epssVuln("CVE-2", 0.8));
+        assertFalse(invoke(builder(true, "CVE-1,CVE-2"), 0.5, sbomData(vulns)));
+    }
+
+    @Test
+    public void suppressionMatchIsCaseInsensitive() throws Exception {
+        List<Vulnerability> vulns = Collections.singletonList(epssVuln("cve-2024-1234", 0.9));
+        assertFalse(invoke(builder(true, "CVE-2024-1234"), 0.5, sbomData(vulns)));
+    }
+
+    private boolean invoke(AmazonInspectorBuilder builder, double threshold, SbomData data) throws Exception {
+        return (boolean) assessMethod.invoke(builder, listener, threshold, data);
+    }
+
+    private static AmazonInspectorBuilder builder(boolean suppressionEnabled, String suppressedList) {
+        return new AmazonInspectorBuilder(
+                "test", "test", "container", false, "", "us-east-1", "", "", "",
+                "automatic", "", 0, 0, 0, 0, "", "", 0.5, suppressedList,
+                suppressionEnabled, false, "", false, true, true);
+    }
+
+    private static SbomData sbomData(List<Vulnerability> vulnerabilities) {
+        return SbomData.builder().sbom(Sbom.builder().vulnerabilities(vulnerabilities).build()).build();
+    }
+
+    private static Vulnerability epssVuln(String id, double score) {
+        Rating epss = Rating.builder().source(Source.builder().name("EPSS").build()).score(score).build();
+        return Vulnerability.builder().id(id).ratings(Collections.singletonList(epss)).build();
+    }
+
+    private static Vulnerability noEpssVuln(String id) {
+        return Vulnerability.builder().id(id).ratings(Collections.emptyList()).build();
+    }
+}


### PR DESCRIPTION
<h3>Problem</h3>
<p>The EPSS gate read the on-disk inventory SBOM (components only, no <code>vulnerabilities[]</code>), so it always saw zero vulnerabilities and never failed builds. The actual scan response with EPSS data was already in memory but never used.</p>
<h3>Fix</h3>
<p>Pass <code>sbomData</code> (the in-memory scan response) to <code>assessCVEsAgainstEPSS</code>. Same source the working severity gate uses.</p>
<h3>Verification</h3>
<p>Tested on Jenkins against <code>ubuntu:18.04</code>. Screenshots below.</p>

Threshold | Result
-- | --
0.1 | FAILURE — CVE-2024-2961 (EPSS 0.918) listed
0.99 | SUCCESS — all CVEs below threshold
Severity gate (control) | FAILURE — 11 High + 11 Medium CVEs listed


<p>Same image, same scan — threshold 0.1 fails and 0.99 passes.</p>
<p>70 unit tests pass (11 new in <code>AmazonInspectorBuilderEpssTest</code>).</p>
<h3>Dependency updates</h3>
<p>Pushed the dependabot bumps that don't break the build:</p>
<ul>
<li><code>awssdk:bom</code> 2.42.4 → 2.42.25</li>
<li><code>jackson-databind</code> 2.20.1 → 2.21.2</li>
<li><code>lombok</code> 1.18.42 → 1.18.44</li>
<li><code>structs</code> 353 → 362</li>
</ul>
<p>Pinned commons-beanutils 1.11.0 (with commons-logging excluded). The recent opencsv 5.12 bump on main brings it in transitively, which trips the parent's RequireUpperBoundDeps rule against an older managed version. Excluding commons-logging because the version it pulls (1.3.5) is on the parent's banned list — Jenkins core already provides it.</p>
<h3>Rollbacks</h3>
<p>Two recent dependabot merges target plugin versions that don't exist in <code>repo.jenkins-ci.org</code>. Rolled both back.</p>
<p><strong><code>jackson2-api</code> 2.21.0-428.v87fd3700d79d → 2.19.2-408.v18248a_324cfe</strong> (PR #176)</p>
<p><code>mvn package</code> on <code>main</code> failed: <code>Could not find artifact ... jackson2-api:jar:2.21.0-428.v87fd3700d79d</code>. Confirmed missing — latest published is <code>2.21.2-436.v29efdb_7418ff</code>.</p>
<p><strong><code>plain-credentials</code> 209.vc1e7c6295cff → 199.v9f8e1f741799</strong> (PR #173)</p>
<p>Build compiled but plugin failed to load on Jenkins startup with <code>Update required: Plain Credentials Plugin ... 209.vc1e7c6295cff or higher</code>. Confirmed missing — latest published is <code>199.v9f8e1f741799</code>.</p>
<h3>Screenshots</h3>


<p><strong>Build  1— threshold 0.1, FAILURE:</strong></p>
<!-- paste -->
<img width="2541" height="1298" alt="image" src="https://github.com/user-attachments/assets/2be90840-8d43-4313-bb9f-f642540aa2cd" />


<p><strong>Build 2— severity gate FAILURE (control):</strong></p>
<!-- paste -->
<img width="2541" height="1298" alt="image" src="https://github.com/user-attachments/assets/c3e78743-72a4-4b6f-9fb3-85d4414422e8" />


<p><strong>Build 3 — threshold 0.99, SUCCESS:</strong></p>
<!-- paste -->
<img width="2541" height="1298" alt="image" src="https://github.com/user-attachments/assets/b4af2918-34ce-4849-ad97-66dd99d59de1" />

