### PR TITLE
test: migrate tests to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.version>2.479.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     </properties>
 
     <dependencyManagement>
@@ -105,13 +106,6 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderEpssTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderEpssTest.java
@@ -6,8 +6,8 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Source;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import hudson.model.TaskListener;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -16,18 +16,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AmazonInspectorBuilderEpssTest {
+class AmazonInspectorBuilderEpssTest {
 
     private TaskListener listener;
     private Method assessMethod;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         listener = mock(TaskListener.class);
         when(listener.getLogger()).thenReturn(new PrintStream(new ByteArrayOutputStream()));
 
@@ -37,53 +37,53 @@ public class AmazonInspectorBuilderEpssTest {
     }
 
     @Test
-    public void emptyVulnerabilitiesReturnsFalse() throws Exception {
+    void emptyVulnerabilitiesReturnsFalse() throws Exception {
         assertFalse(invoke(builder(false, ""), 0.5, sbomData(Collections.emptyList())));
     }
 
     @Test
-    public void nullVulnerabilitiesReturnsFalse() throws Exception {
+    void nullVulnerabilitiesReturnsFalse() throws Exception {
         assertFalse(invoke(builder(false, ""), 0.5, sbomData(null)));
     }
 
     @Test
-    public void vulnAboveThresholdReturnsTrue() throws Exception {
+    void vulnAboveThresholdReturnsTrue() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.8));
         assertTrue(invoke(builder(false, ""), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void vulnBelowThresholdReturnsFalse() throws Exception {
+    void vulnBelowThresholdReturnsFalse() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.1));
         assertFalse(invoke(builder(false, ""), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void vulnEqualToThresholdReturnsTrue() throws Exception {
+    void vulnEqualToThresholdReturnsTrue() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.5));
         assertTrue(invoke(builder(false, ""), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void nullEpssScoreIsSkipped() throws Exception {
+    void nullEpssScoreIsSkipped() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(noEpssVuln("CVE-1"));
         assertFalse(invoke(builder(false, ""), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void suppressedCveAboveThresholdIsSkippedWhenSuppressionEnabled() throws Exception {
+    void suppressedCveAboveThresholdIsSkippedWhenSuppressionEnabled() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.9));
         assertFalse(invoke(builder(true, "CVE-1"), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void suppressedCveAboveThresholdIsCountedWhenSuppressionDisabled() throws Exception {
+    void suppressedCveAboveThresholdIsCountedWhenSuppressionDisabled() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("CVE-1", 0.9));
         assertTrue(invoke(builder(false, "CVE-1"), 0.5, sbomData(vulns)));
     }
 
     @Test
-    public void mixOfSuppressedAndBreachingCves() throws Exception {
+    void mixOfSuppressedAndBreachingCves() throws Exception {
         List<Vulnerability> vulns = Arrays.asList(
                 epssVuln("CVE-1", 0.9),
                 epssVuln("CVE-2", 0.8),
@@ -92,7 +92,7 @@ public class AmazonInspectorBuilderEpssTest {
     }
 
     @Test
-    public void allSuppressedReturnsFalseEvenWhenAboveThreshold() throws Exception {
+    void allSuppressedReturnsFalseEvenWhenAboveThreshold() throws Exception {
         List<Vulnerability> vulns = Arrays.asList(
                 epssVuln("CVE-1", 0.9),
                 epssVuln("CVE-2", 0.8));
@@ -100,7 +100,7 @@ public class AmazonInspectorBuilderEpssTest {
     }
 
     @Test
-    public void suppressionMatchIsCaseInsensitive() throws Exception {
+    void suppressionMatchIsCaseInsensitive() throws Exception {
         List<Vulnerability> vulns = Collections.singletonList(epssVuln("cve-2024-1234", 0.9));
         assertFalse(invoke(builder(true, "CVE-2024-1234"), 0.5, sbomData(vulns)));
     }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderTest.java
@@ -1,10 +1,12 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
-import org.junit.Test;
-import static org.junit.Assert.*;
-public class AmazonInspectorBuilderTest {
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AmazonInspectorBuilderTest {
 
     @Test
-    public void testConstructorWithNewParameters() {
+    void testConstructorWithNewParameters() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "alpine:latest", 
             "alpine:latest", 
@@ -41,7 +43,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testConstructorWithFalseFlags() {
+    void testConstructorWithFalseFlags() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "ubuntu:20.04", 
             "ubuntu:20.04", 
@@ -82,7 +84,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testGettersReturnCorrectValues() {
+    void testGettersReturnCorrectValues() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test-image:v1.0", 
             "", 
@@ -130,7 +132,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testNullEpssThreshold() {
+    void testNullEpssThreshold() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", null, "",
@@ -144,7 +146,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testEmptyStringParameters() {
+    void testEmptyStringParameters() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "", "", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.0, "",
@@ -161,7 +163,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testBoundaryValueThresholds() {
+    void testBoundaryValueThresholds() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
@@ -180,7 +182,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testZeroThresholds() {
+    void testZeroThresholds() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0,
@@ -199,7 +201,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testMixedFeatureFlags() {
+    void testMixedFeatureFlags() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "alpine:3.18", "alpine:3.18", "container", true, "arn:aws:iam::123456789012:role/test", 
             "ap-southeast-1", "jenkins-cred", "dev-profile", "aws-cred-123",
@@ -223,7 +225,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testComplexCveStrings() {
+    void testComplexCveStrings() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.5,
@@ -240,7 +242,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testSingleCveStrings() {
+    void testSingleCveStrings() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.5,
@@ -257,7 +259,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testAllArchiveTypes() {
+    void testAllArchiveTypes() {
         AmazonInspectorBuilder containerBuilder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", null, "",
@@ -280,7 +282,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testAllRegions() {
+    void testAllRegions() {
         String[] regions = {"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ca-central-1"};
 
         for (String region : regions) {
@@ -297,7 +299,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testSbomgenSelectionOptions() {
+    void testSbomgenSelectionOptions() {
         String[] selections = {"automatic", "manual"};
 
         for (String selection : selections) {
@@ -314,7 +316,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testFeatureFlagCombinations() {
+    void testFeatureFlagCombinations() {
         boolean[] flags = {true, false};
 
         for (boolean severityFlag : flags) {
@@ -341,7 +343,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testSpecialCharactersInPaths() {
+    void testSpecialCharactersInPaths() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "/path with spaces/image-name_v1.0:latest", 
             "/path with spaces/image-name_v1.0:latest", 
@@ -371,7 +373,7 @@ public class AmazonInspectorBuilderTest {
     }
 
     @Test
-    public void testLegacyParameterBackwardCompatibility() {
+    void testLegacyParameterBackwardCompatibility() {
         AmazonInspectorBuilder builder = new AmazonInspectorBuilder(
             "test", "test", "container", false, "", "us-east-1", "", "", "",
             "automatic", "", 0, 0, 0, 0, "", "", 0.5, "",

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/TestUtils.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/TestUtils.java
@@ -6,13 +6,13 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class TestUtils {
+
     public static String readStringFromFile(String filePath) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
+        return Files.readString(Paths.get(filePath));
     }
 
     public static SbomData getSbomDataFromString(String rawSbom) {

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverterTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverterTest.java
@@ -16,28 +16,28 @@ import java.util.HashMap;
 import java.util.List;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.OTHER;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class CsvConverterTest {
+class CsvConverterTest {
 
     private CsvConverter csvConverter;
     private SbomData sbomData;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void beforeEach() throws IOException {
         sbomData = new Gson().fromJson(TestUtils.readStringFromFile("src/test/resources/data/SbomOutputExample.json"), SbomData.class);
     }
 
     @Test
-    public void convertVulnerabilities_shouldReturnNull_whenNoVulnData() throws IOException {
+    void convertVulnerabilities_shouldReturnNull_whenNoVulnData() throws IOException {
         csvConverter = new CsvConverter(sbomData);
         SeverityCounts counts = new SeverityCounts();
-        assertEquals(null, csvConverter.convertVulnerabilities("imageName", "imageSha", "buildId", counts));
+        assertNull(csvConverter.convertVulnerabilities("imageName", "imageSha", "buildId", counts));
     }
 
     @Test
-    public void convertVulnerabilities_normalBehavior() throws IOException {
+    void convertVulnerabilities_normalBehavior() throws IOException {
         csvConverter = new CsvConverter(sbomData);
         csvConverter.routeVulnerabilities();
         SeverityCounts counts = new SeverityCounts();
@@ -45,14 +45,14 @@ public class CsvConverterTest {
     }
 
     @Test
-    public void convertDocker_shouldReturnNull_whenNoDockerData() throws IOException {
+    void convertDocker_shouldReturnNull_whenNoDockerData() throws IOException {
         csvConverter = new CsvConverter(sbomData);
         SeverityCounts counts = new SeverityCounts();
-        assertEquals(null, csvConverter.convertDocker("imageName", "imageSha", "buildId", counts));
+        assertNull(csvConverter.convertDocker("imageName", "imageSha", "buildId", counts));
     }
 
     @Test
-    public void convertDocker_normalBehavior() throws IOException {
+    void convertDocker_normalBehavior() throws IOException {
         csvConverter = new CsvConverter(sbomData);
         csvConverter.routeVulnerabilities();
         SeverityCounts counts = new SeverityCounts();
@@ -60,28 +60,28 @@ public class CsvConverterTest {
     }
 
     @Test
-    public void populateComponentMap_shouldReturnEmptyMap_whenSbomDataIsNull() {
+    void populateComponentMap_shouldReturnEmptyMap_whenSbomDataIsNull() {
         SbomData sbomData = null;
         csvConverter = new CsvConverter(sbomData);
         assertEquals(new HashMap<>(), csvConverter.populateComponentMap(sbomData));
     }
 
     @Test
-    public void populateComponentMap_shouldReturnEmptyMap_whenSbomDataHasNoComponents() {
+    void populateComponentMap_shouldReturnEmptyMap_whenSbomDataHasNoComponents() {
         sbomData.setSbom(null);
         csvConverter = new CsvConverter(sbomData);
         assertEquals(new HashMap<>(), csvConverter.populateComponentMap(sbomData));
     }
 
     @Test
-    public void routeVulnerabilities_shouldNotThrowException_whenVulnerabilitiesAreNull() {
+    void routeVulnerabilities_shouldNotThrowException_whenVulnerabilitiesAreNull() {
         csvConverter = new CsvConverter(sbomData);
         csvConverter.routeVulnerabilities(); // No exception expected
     }
 
 
     @Test
-    public void routeVulnCsvData_vulnListSizes_nonINDOCKERVulnId() {
+    void routeVulnCsvData_vulnListSizes_nonINDOCKERVulnId() {
         csvConverter = new CsvConverter(sbomData);
         Vulnerability vulnerability = Vulnerability.builder().id("123").build();
         Component component = Component.builder().build();
@@ -92,14 +92,14 @@ public class CsvConverterTest {
     }
 
     @Test
-    public void getSeverity_emptyRatingsReturnsOTHER() {
+    void getSeverity_emptyRatingsReturnsOTHER() {
         csvConverter = new CsvConverter(sbomData);
         Vulnerability vulnerability = Vulnerability.builder().ratings(new ArrayList<>()).build();
-        assertTrue(csvConverter.getSeverity(vulnerability).equals(OTHER.name()));
+        assertEquals(csvConverter.getSeverity(vulnerability), OTHER.name());
     }
 
     @Test
-    public void getProprtyValueFromKey_returnsProperty() {
+    void getPropertyValueFromKey_returnsProperty() {
         csvConverter = new CsvConverter(sbomData);
         String key = "value";
         List<Property> properties = List.of(Property.builder().name(key).value(key).build());

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtilsTest.java
@@ -12,39 +12,39 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.html.HtmlConversionUtils.sortVulnerabilitiesBySeverity;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.ConversionUtils.getSeverity;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HtmlConversionUtilsTest {
-    SbomData sbomData;
+class HtmlConversionUtilsTest {
 
-    @Before
-    public void setUp() throws IOException {
+    private SbomData sbomData;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
         String str = TestUtils.readStringFromFile("src/test/resources/data/SbomOutputExampleUbuntu.json");
         sbomData = TestUtils.getSbomDataFromString(str);
     }
 
     @Test
-    public void testConvertVulnerabilities() {
+    void testConvertVulnerabilities() {
         List<Vulnerability> vulnerabilities = sbomData.getSbom().getVulnerabilities();
         List<Component> components = sbomData.getSbom().getComponents();
 
         List<HtmlVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertVulnerabilities(vulnerabilities,
                 components);
 
-        assertEquals(htmlVulnerabilities.size(), 396);
+        assertEquals(396, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertVulnerabilities_emptyComponents() {
+    void testConvertVulnerabilities_emptyComponents() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("ID")
                 .ratings(List.of(Rating.builder().source(
@@ -64,7 +64,7 @@ public class HtmlConversionUtilsTest {
     }
 
     @Test
-    public void testConvertVulnerabilities_nullSeverity() {
+    void testConvertVulnerabilities_nullSeverity() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("ID")
                 .ratings(List.of())
@@ -80,11 +80,11 @@ public class HtmlConversionUtilsTest {
 
         List<HtmlVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertVulnerabilities(vulnerabilities, components);
 
-        assertEquals(htmlVulnerabilities.get(0).severity, "UNTRIAGED");
+        assertEquals("UNTRIAGED", htmlVulnerabilities.get(0).severity);
     }
 
     @Test
-    public void testConvertVulnerabilities_skipsDocker() {
+    void testConvertVulnerabilities_skipsDocker() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
                 .build();
@@ -92,18 +92,18 @@ public class HtmlConversionUtilsTest {
 
         List<HtmlVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertVulnerabilities(vulnerabilities, null);
 
-        assertEquals(htmlVulnerabilities.size(), 0);
+        assertEquals(0, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertVulnerabilities_nullVulnerabilities() {
+    void testConvertVulnerabilities_nullVulnerabilities() {
         List<HtmlVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertVulnerabilities(null, null);
 
-        assertEquals(htmlVulnerabilities.size(), 0);
+        assertEquals(0, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertDocker() {
+    void testConvertDocker() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
                 .ratings(List.of(Rating.builder().source(
@@ -124,11 +124,11 @@ public class HtmlConversionUtilsTest {
 
         List<DockerVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertDocker(vulnerabilities, components);
 
-        assertEquals(htmlVulnerabilities.size(), 1);
+        assertEquals(1, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertDocker_emptyComponents() {
+    void testConvertDocker_emptyComponents() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
                 .ratings(List.of(Rating.builder().source(
@@ -144,11 +144,11 @@ public class HtmlConversionUtilsTest {
 
         List<DockerVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertDocker(vulnerabilities, components);
 
-        assertEquals(htmlVulnerabilities.size(), 1);
+        assertEquals(1, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertDocker_nullSeverity() {
+    void testConvertDocker_nullSeverity() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
                 .ratings(List.of())
@@ -165,11 +165,11 @@ public class HtmlConversionUtilsTest {
 
         List<DockerVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertDocker(vulnerabilities, components);
 
-        assertEquals(htmlVulnerabilities.get(0).severity, "UNTRIAGED");
+        assertEquals("UNTRIAGED", htmlVulnerabilities.get(0).severity);
     }
 
     @Test
-    public void testConvertDocker_skipsVuln() {
+    void testConvertDocker_skipsVuln() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("ID")
                 .build();
@@ -177,18 +177,18 @@ public class HtmlConversionUtilsTest {
 
         List<DockerVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertDocker(vulnerabilities, null);
 
-        assertEquals(htmlVulnerabilities.size(), 0);
+        assertEquals(0, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertDocker_nullVulnerabilities() {
+    void testConvertDocker_nullVulnerabilities() {
         List<DockerVulnerability> htmlVulnerabilities = HtmlConversionUtils.convertDocker(null, null);
 
-        assertEquals(htmlVulnerabilities.size(), 0);
+        assertEquals(0, htmlVulnerabilities.size());
     }
 
     @Test
-    public void testConvertDocker_derivedDockerfile() {
+    void testConvertDocker_derivedDockerfile() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
                 .ratings(List.of(Rating.builder().source(
@@ -213,49 +213,49 @@ public class HtmlConversionUtilsTest {
     }
 
     @Test
-    public void testGetLines() {
+    void testGetLines() {
         String id = "testId";
         List<Property> properties = List.of(Property.builder()
                         .value("affected_lines:6-6")
                         .name(id)
                 .build());
-        assertEquals(HtmlConversionUtils.getLines(id, properties), "6");
+        assertEquals("6", HtmlConversionUtils.getLines(id, properties));
     }
 
     @Test
-    public void testGetLines_multipleLines() {
+    void testGetLines_multipleLines() {
         String id = "testId";
         List<Property> properties = List.of(Property.builder()
                 .value("affected_lines:6-7")
                 .name(id)
                 .build());
-        assertEquals(HtmlConversionUtils.getLines(id, properties), "6-7");
+        assertEquals("6-7", HtmlConversionUtils.getLines(id, properties));
     }
 
     @Test
-    public void testGetLines_nullProperties() {
-        assertEquals(HtmlConversionUtils.getLines(null, null), "N/A");
+    void testGetLines_nullProperties() {
+        assertEquals("N/A", HtmlConversionUtils.getLines(null, null));
     }
 
     @Test
-    public void testGetLines_noApplicableLines() {
+    void testGetLines_noApplicableLines() {
         String id = "testId";
         List<Property> properties = List.of(Property.builder()
                 .value("affected_lines:6-6")
                 .name(id)
                 .build());
-        assertEquals(HtmlConversionUtils.getLines("invalid", properties), "N/A");
+        assertEquals("N/A", HtmlConversionUtils.getLines("invalid", properties));
     }
 
     @Test
-    public void testSortVulnerabilitiesBySeverity() {
-        assertEquals(sortVulnerabilitiesBySeverity("high", "low"), -2);
-        assertEquals(sortVulnerabilitiesBySeverity("low", "high"), 2);
-        assertEquals(sortVulnerabilitiesBySeverity("high", "high"), 0);
+    void testSortVulnerabilitiesBySeverity() {
+        assertEquals(-2, sortVulnerabilitiesBySeverity("high", "low"));
+        assertEquals(2, sortVulnerabilitiesBySeverity("low", "high"));
+        assertEquals(0, sortVulnerabilitiesBySeverity("high", "high"));
     }
 
     @Test
-    public void testGetSeverity_noNVD() {
+    void testGetSeverity_noNVD() {
         Vulnerability vuln = Vulnerability.builder().ratings(List.of(
                 Rating.builder()
                         .severity("low")
@@ -263,7 +263,7 @@ public class HtmlConversionUtilsTest {
                         .source(Source.builder()
                                 .name("NonNVD").build()
                         ).build())).build();
-        assertEquals(getSeverity(vuln)
-                , Severity.UNTRIAGED);
+        assertEquals(Severity.UNTRIAGED, getSeverity(vuln)
+        );
     }
 }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloaderTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloaderTest.java
@@ -3,16 +3,16 @@ package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SbomgenDownloaderTest {
+class SbomgenDownloaderTest {
 
     @Test
-    public void testAgentEnvironmentVariableAccess() throws Exception {
+    void testAgentEnvironmentVariableAccess() throws Exception {
         FilePath mockWorkspace = mock(FilePath.class);
         VirtualChannel mockChannel = mock(VirtualChannel.class);
         EnvVars mockEnv = mock(EnvVars.class);
@@ -21,27 +21,24 @@ public class SbomgenDownloaderTest {
         when(mockWorkspace.getChannel()).thenReturn(mockChannel);
         when(mockEnv.getRemote(mockChannel)).thenReturn(mockRemoteEnv);
         when(mockRemoteEnv.get("HOSTTYPE")).thenReturn("aarch64");
-        
+
         // Verify agent environment variables can be accessed for architecture detection
-        assertTrue("Should successfully access agent environment variables", 
-                   mockRemoteEnv.get("HOSTTYPE").equals("aarch64"));
-        assertTrue("Should have remote channel available", 
-                   mockWorkspace.getChannel() != null);
+        assertEquals("aarch64", mockRemoteEnv.get("HOSTTYPE"), "Should successfully access agent environment variables");
+        assertNotNull(mockWorkspace.getChannel(), "Should have remote channel available");
     }
 
     @Test
-    public void testFallbackWhenNoRemoteChannel() throws Exception {
+    void testFallbackWhenNoRemoteChannel() {
         FilePath mockWorkspace = mock(FilePath.class);
         
         when(mockWorkspace.getChannel()).thenReturn(null);
-        
+
         // Test fallback scenario when no agent channel available
-        assertTrue("Should fallback to local execution when no remote channel", 
-                   mockWorkspace.getChannel() == null);
+        assertNull(mockWorkspace.getChannel(), "Should fallback to local execution when no remote channel");
     }
-    
+
     @Test
-    public void testEnvironmentVariableFallbackChain() throws Exception {
+    void testEnvironmentVariableFallbackChain() throws Exception {
         FilePath mockWorkspace = mock(FilePath.class);
         VirtualChannel mockChannel = mock(VirtualChannel.class);
         EnvVars mockEnv = mock(EnvVars.class);
@@ -51,10 +48,9 @@ public class SbomgenDownloaderTest {
         when(mockEnv.getRemote(mockChannel)).thenReturn(mockRemoteEnv);
         when(mockRemoteEnv.get("HOSTTYPE")).thenReturn(null);
         when(mockRemoteEnv.get("MACHTYPE")).thenReturn("x86_64-pc-linux-gnu");
-        
+
         // Test fallback from HOSTTYPE to MACHTYPE
-        assertTrue("Should try HOSTTYPE first", mockRemoteEnv.get("HOSTTYPE") == null);
-        assertTrue("Should fallback to MACHTYPE when HOSTTYPE unavailable", 
-                   mockRemoteEnv.get("MACHTYPE").equals("x86_64-pc-linux-gnu"));
+        assertNull(mockRemoteEnv.get("HOSTTYPE"), "Should try HOSTTYPE first");
+        assertEquals("x86_64-pc-linux-gnu", mockRemoteEnv.get("MACHTYPE"), "Should fallback to MACHTYPE when HOSTTYPE unavailable");
     }
 }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
@@ -2,17 +2,16 @@ package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SbomgenRunnerTest {
+class SbomgenRunnerTest {
 
     @Test
-    public void testIsValidPath() {
+    void testIsValidPath() {
         SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
         
         // Valid paths (matching regex: ^[a-zA-Z0-9/._\-: ]+$)
@@ -38,7 +37,7 @@ public class SbomgenRunnerTest {
     }
 
     @Test
-    public void testIsValidPathEdgeCases() {
+    void testIsValidPathEdgeCases() {
         SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
         
         // Edge cases that should be invalid
@@ -55,14 +54,15 @@ public class SbomgenRunnerTest {
         assertTrue(runner.isValidPath("/tmp/this_file_does_not_exist.tar"));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testIsValidPathWithNull() {
+    @Test
+    void testIsValidPathWithNull() {
         SbomgenRunner runner = new SbomgenRunner(null, null, null, null, null, null, null, null, false);
-        runner.isValidPath(null);
+        assertThrows(NullPointerException.class, () ->
+            runner.isValidPath(null));
     }
 
     @Test
-    public void testWorkspaceChannelDetectionForRemoteAgent() throws Exception {
+    void testWorkspaceChannelDetectionForRemoteAgent() {
         FilePath mockWorkspace = mock(FilePath.class);
         VirtualChannel mockChannel = mock(VirtualChannel.class);
         
@@ -71,20 +71,18 @@ public class SbomgenRunnerTest {
         SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
         
         // Verify the runner correctly identifies remote agent scenario
-        assertTrue("Should detect remote agent when workspace has channel", 
-                   runner.workspace.getChannel() != null);
+        assertNotNull(runner.workspace.getChannel(), "Should detect remote agent when workspace has channel");
     }
 
     @Test
-    public void testWorkspaceChannelDetectionForLocalExecution() throws Exception {
+    void testWorkspaceChannelDetectionForLocalExecution() {
         FilePath mockWorkspace = mock(FilePath.class);
         
         when(mockWorkspace.getChannel()).thenReturn(null);
         
         SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
-        
+
         // Verify the runner correctly identifies local execution scenario
-        assertTrue("Should detect local execution when workspace has no channel", 
-                   runner.workspace.getChannel() == null);
+        assertNull(runner.workspace.getChannel(), "Should detect local execution when workspace has no channel");
     }
 }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
@@ -1,22 +1,24 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
         
+import org.junit.jupiter.api.Test;
+
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.exception.MalformedScanOutputException;
-import org.junit.Test;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.processSbomgenOutput;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.stripProperties;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class SbomgenUtilsTest {
+class SbomgenUtilsTest {
+
     @Test
-    public void testProcessSbomgenOutput() throws MalformedScanOutputException {
+    void testProcessSbomgenOutput() throws MalformedScanOutputException {
         String sbom = "time=dwadaw file=wdadawdwada\n{\ntest\n}\nbdwadawdaw";
-        assertEquals(processSbomgenOutput(sbom), "{\ntest\n}");
+        assertEquals("{\ntest\n}", processSbomgenOutput(sbom));
     }
 
     @Test
-    public void testStripProperties() {
+    void testStripProperties() {
         String bom = "{\"components\": [{\"properties\": []}]}";
         assertFalse(stripProperties(bom).contains("\"properties\""));
     }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParserTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParserTest.java
@@ -4,30 +4,31 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Sbom;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
-import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
-public class SbomOutputParserTest {
+class SbomOutputParserTest {
+
     @Test
-    public void testGetHighestRatingFromList_Successful() {
+    void testGetHighestRatingFromList_Successful() {
         List<Rating> ratings = List.of(
                 Rating.builder().severity(Severity.HIGH.name()).build(),
                 Rating.builder().severity(Severity.LOW.name()).build());
 
-        assertEquals(new SbomOutputParser(null).getHighestRatingFromList(ratings), Severity.HIGH);
+        assertEquals(Severity.HIGH, new SbomOutputParser(null).getHighestRatingFromList(ratings));
     }
 
     @Test
-    public void testGetHighestRatingFromList_EmptyRatings() {
-        assertEquals(new SbomOutputParser(null).getHighestRatingFromList(null), Severity.OTHER);
-        assertEquals(new SbomOutputParser(null).getHighestRatingFromList(List.of()), Severity.OTHER);
+    void testGetHighestRatingFromList_EmptyRatings() {
+        assertEquals(Severity.OTHER, new SbomOutputParser(null).getHighestRatingFromList(null));
+        assertEquals(Severity.OTHER, new SbomOutputParser(null).getHighestRatingFromList(List.of()));
     }
 
     @Test
-    public void testParseSbom_Successful() {
+    void testParseSbom_Successful() {
         SbomData sbomData = SbomData.builder().sbom(Sbom.builder().vulnerabilities(
                 List.of(Vulnerability.builder().id("CVE").ratings(
                         List.of(

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtilsTest.java
@@ -5,24 +5,25 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.SeverityCounts;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Map;
 
-public class ConversionUtilsTest {
-    SbomData sbomData;
+class ConversionUtilsTest {
 
-    @Before
-    public void setUp() throws IOException {
+    private SbomData sbomData;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
         String str = TestUtils.readStringFromFile("src/test/resources/data/SbomOutputExampleUbuntu.json");
         sbomData = TestUtils.getSbomDataFromString(str);
     }
 
     @Test
-    public void testGetSeverities() {
+    void testGetSeverities() {
         SeverityCounts severityCounts = new SeverityCounts();
 
         for (Vulnerability vulnerability : sbomData.getSbom().getVulnerabilities()) {
@@ -31,10 +32,10 @@ public class ConversionUtilsTest {
         }
 
         Map<Severity, Integer> severityMap = severityCounts.getCounts();
-        Assert.assertEquals(Integer.valueOf(47), severityMap.get(Severity.CRITICAL));
-        Assert.assertEquals(Integer.valueOf(214), severityMap.get(Severity.HIGH));
-        Assert.assertEquals(Integer.valueOf(110), severityMap.get(Severity.MEDIUM));
-        Assert.assertEquals(Integer.valueOf(9), severityMap.get(Severity.LOW));
-        Assert.assertEquals(Integer.valueOf(0), severityMap.get(Severity.OTHER));
+        assertEquals(Integer.valueOf(47), severityMap.get(Severity.CRITICAL));
+        assertEquals(Integer.valueOf(214), severityMap.get(Severity.HIGH));
+        assertEquals(Integer.valueOf(110), severityMap.get(Severity.MEDIUM));
+        assertEquals(Integer.valueOf(9), severityMap.get(Severity.LOW));
+        assertEquals(Integer.valueOf(0), severityMap.get(Severity.OTHER));
     }
 }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
@@ -1,22 +1,22 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils;
 
-import org.junit.Test;
-
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import org.junit.jupiter.api.Test;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeFilePath;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeText;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SanitizerTest {
+class SanitizerTest {
+
     @Test
-    public void testSanitizeFilePath() throws MalformedURLException, URISyntaxException {
-        assertEquals(sanitizeFilePath("file:///test test/{}test"), "file:///test%20test/%7B%7Dtest");
+    void testSanitizeFilePath() {
+        assertEquals("file:///test%20test/%7B%7Dtest", sanitizeFilePath("file:///test test/{}test"));
     }
 
     @Test
-    public void testSanitizeNonUrl() throws MalformedURLException, URISyntaxException {
-        assertEquals(sanitizeText("test:test{}"), "test:test%7B%7D");
+    void testSanitizeNonUrl() throws URISyntaxException {
+        assertEquals("test:test%7B%7D", sanitizeText("test:test{}"));
     }
 }


### PR DESCRIPTION
### Summary

Migrates all unit tests from JUnit 4 to JUnit Jupiter. Builds on the work proposed in the upstream Jenkins fork by [@strangelookingnerd](https://github.com/strangelookingnerd) in jenkinsci#155 Their original PR was opened in November 2025 against the upstream fork and never merged.

### Changes

- 9 existing test classes migrated: `org.junit.Test` → `org.junit.jupiter.api.Test`, `@Before` → `@BeforeEach`, `org.junit.Assert.*` → `org.junit.jupiter.api.Assertions.*`, dropped `public` visibility on test classes/methods
- Added `AmazonInspectorBuilderEpssTest` to the migration (this file landed in #182 after the upstream PR was opened)
- Removed the now-unused `junit:junit` dependency from `pom.xml`
- Added the `ban-junit4-imports.skip=false` enforcer property to prevent regressions
- Small cleanup in `TestUtils`: `Files.readAllBytes(...) + new String(...)` → `Files.readString(...)`

### Verification

- All 70 tests pass under Jupiter (`mvn clean test`)
- Built and uploaded the `.hpi` to a real Jenkins instance — plugin loads cleanly, runs a full scan against `alpine:latest`, build completes successfully
- Confirmed zero remaining JUnit 4 imports in the test sources

### Credit

Authored together with [[@strangelookingnerd](https://github.com/strangelookingnerd)](https://github.com/strangelookingnerd) (`Co-authored-by` trailer on the commit). Their migration is the bulk of this PR; we resolved the parent POM conflict against current `main`, added the missing test file, and removed the dead JUnit 4 dependency.

---


<img width="1822" height="819" alt="image" src="https://github.com/user-attachments/assets/8d567c40-6778-4326-92c3-d5a8b25ac480" />
