### PR TITLE
build: add CI workflow, bump Java to 17, replace deprecated Jenkins APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Run tests
+        run: mvn -B -ntp test
+
+      - name: Build plugin
+        run: mvn -B -ntp -DskipTests package

--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,8 @@
                     <mojoStatusPath/>
                     <outputDirectory/>
                     <projectArtifact/>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -61,7 +61,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.InspectorRegions.INSPECTOR_REGIONS;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeFilePath;
@@ -838,7 +838,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         }
 
         @Override
-        public AmazonInspectorBuilder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public AmazonInspectorBuilder newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             String sourceVal = formData.optString("sbomgenSource", null);
             formData.put("sbomgenSource", sourceVal);
 
@@ -860,10 +860,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
         private ListBoxModel getCredentialIdModels() {
             ListBoxModel items = new ListBoxModel();
-            List<StandardUsernamePasswordCredentials> credentials = CredentialsProvider.lookupCredentials(
+            List<StandardUsernamePasswordCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
                     StandardUsernamePasswordCredentials.class,
-                    Jenkins.getInstance(),
-                    ACL.SYSTEM,
+                    Jenkins.get(),
+                    ACL.SYSTEM2,
                     Collections.emptyList()
             );
 
@@ -880,10 +880,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
         private ListBoxModel getOidcStringIdModels() {
             ListBoxModel items = new ListBoxModel();
-            List<IdTokenStringCredentials> credentials = CredentialsProvider.lookupCredentials(
+            List<IdTokenStringCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
                     IdTokenStringCredentials.class,
-                    Jenkins.getInstance(),
-                    ACL.SYSTEM,
+                    Jenkins.get(),
+                    ACL.SYSTEM2,
                     Collections.emptyList()
             );
 
@@ -896,10 +896,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
         private ListBoxModel getOidcFileIdModels() {
             ListBoxModel items = new ListBoxModel();
-            List<IdTokenFileCredentials> credentials = CredentialsProvider.lookupCredentials(
+            List<IdTokenFileCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
                     IdTokenFileCredentials.class,
-                    Jenkins.getInstance(),
-                    ACL.SYSTEM,
+                    Jenkins.get(),
+                    ACL.SYSTEM2,
                     Collections.emptyList()
             );
 
@@ -1074,10 +1074,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         @SuppressFBWarnings()
         private ListBoxModel getAwsCredentialIdModels() {
             ListBoxModel items = new ListBoxModel();
-            List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentials(
+            List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
                     AmazonWebServicesCredentials.class,
-                    Jenkins.getInstance(),
-                    ACL.SYSTEM,
+                    Jenkins.get(),
+                    ACL.SYSTEM2,
                     Collections.emptyList()
             );
 


### PR DESCRIPTION
### Summary

Three small infrastructure cleanups that don't conflict with PR #185.

### Changes

**Add CI workflow** (`.github/workflows/build.yml`)
Runs `mvn test` and `mvn package` on every PR and push to main. Closes the gap that let recent broken dependabot bumps merge — they compiled but failed at runtime, and there was no PR-level CI catching it.

**Bump Java baseline 16 → 17** (`pom.xml`)
Aligns the source/target with the Jenkins parent POM baseline, which already requires Java 17+ at runtime.

**Replace deprecated Jenkins APIs** (`AmazonInspectorBuilder.java`)
- `Jenkins.getInstance()` → `Jenkins.get()`
- `ACL.SYSTEM` → `ACL.SYSTEM2`
- `CredentialsProvider.lookupCredentials(...)` → `lookupCredentialsInItemGroup(...)`
- `StaplerRequest` → `StaplerRequest2`

### Verification

70 unit tests pass. Built and uploaded the `.hpi` to Jenkins:
- Plugin loaded cleanly, no errors on startup
- AWS, Docker, and OIDC credential dropdowns all populate
- End-to-end scan against `ubuntu:18.04` completed successfully

### Follow-up

CI runs `mvn test` + `mvn package` rather than `mvn verify` because
`verify` triggers SpotBugs which currently fails on 13 pre-existing
violations on `main`. I'll address those in a follow-up PR after this
merges and switch CI to `mvn verify` then.


### Screenshots

**Plugin loaded successfully (no red banner):**
<!-- paste -->
<img width="1822" height="819" alt="Screenshot 2026-05-28 at 10 47 53 AM" src="https://github.com/user-attachments/assets/58bb0651-49be-4864-9cf9-b80437b7714c" />


**End-to-end build succeeded:**
<!-- paste -->
<img width="1822" height="819" alt="Screenshot 2026-05-28 at 9 26 58 AM" src="https://github.com/user-attachments/assets/25af20d0-0e5f-4504-9950-2fe4307bcde2" />

