### PR TITLE
fix: convert SbomOutputParser and CsvConverter from static to instanc…

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -284,7 +284,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         }
     }
 
-    private void filterSuppressedCvesFromCounts(SbomData sbomData, Set<String> suppressedCveSet, TaskListener listener) {
+    private void filterSuppressedCvesFromCounts(SbomData sbomData, Set<String> suppressedCveSet, TaskListener listener, SbomOutputParser parser) {
         List<Vulnerability> vulnerabilities = sbomData.getSbom().getVulnerabilities();
         if (vulnerabilities == null || vulnerabilities.isEmpty()) {
             return;
@@ -334,7 +334,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         if (suppressedCount > 0) {
             listener.getLogger().println("Suppressing " + suppressedCount + " CVEs from threshold calculations: " + suppressedCveSet);
             
-            Map<Severity, Integer> currentCounts = SbomOutputParser.aggregateCounts.getCounts();
+            Map<Severity, Integer> currentCounts = parser.getAggregateCounts().getCounts();
             for (Map.Entry<Severity, Integer> entry : suppressedCounts.entrySet()) {
                 if (entry.getValue() > 0) {
                     int newCount = Math.max(0, currentCounts.get(entry.getKey()) - entry.getValue());
@@ -618,7 +618,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                     suppressedCveSet.add(cve.trim().toUpperCase());
                 }
                 suppressedCount = suppressedCveSet.size();
-                filterSuppressedCvesFromCounts(sbomData, suppressedCveSet, listener);
+                filterSuppressedCvesFromCounts(sbomData, suppressedCveSet, listener, parser);
             }
 
             String sanitizedArchiveName = null;
@@ -634,13 +634,13 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             }
 
             converter.routeVulnerabilities();
-            String csvVulnContent = converter.convertVulnerabilities(sanitizedArchiveName, imageSha, build.getId(), SbomOutputParser.vulnCounts);
+            String csvVulnContent = converter.convertVulnerabilities(sanitizedArchiveName, imageSha, build.getId(), parser.getVulnCounts());
             if (csvVulnContent != null) {
                 artifactMap.put(csvVulnFileName, csvVulnWorkspacePath);
                 csvVulnFile.write(csvVulnContent, "UTF-8");
             }
 
-            String csvDockerContent = converter.convertDocker(sanitizedArchiveName, imageSha, build.getId(), SbomOutputParser.dockerCounts);
+            String csvDockerContent = converter.convertDocker(sanitizedArchiveName, imageSha, build.getId(), parser.getDockerCounts());
             if (csvDockerContent != null) {
                 artifactMap.put(csvDockerFileName, csvDockerWorkspacePath);
                 csvDockerFile.write(csvDockerContent, "UTF-8");
@@ -695,10 +695,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             }
 
             if (isSeverityThresholdEnabled) {
-                boolean vulnThresholdsFailed = doesBuildFail(SbomOutputParser.aggregateCounts.getCounts());
+                boolean vulnThresholdsFailed = doesBuildFail(parser.getAggregateCounts().getCounts());
                 if (vulnThresholdsFailed) {
                     doesBuildPass = false;
-                    logThresholdBreachDetails(sbomData, listener, SbomOutputParser.aggregateCounts.getCounts());
+                    logThresholdBreachDetails(sbomData, listener, parser.getAggregateCounts().getCounts());
                 }
             } else {
                 listener.getLogger().println("Vulnerability thresholds disabled. Skipping threshold checks.");
@@ -721,7 +721,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             }
 
             if (isSeverityThresholdEnabled) {
-                listener.getLogger().println("Results: " + SbomOutputParser.aggregateCounts.toString());
+                listener.getLogger().println("Results: " + parser.getAggregateCounts().toString());
             }
 
             logSecurityAssessmentSummary(listener, suppressedCveSet, suppressedCount);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverter.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverter.java
@@ -12,6 +12,7 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Getter;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
@@ -29,17 +30,16 @@ import java.util.Map;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.html.HtmlConversionUtils.getLineComponents;
 
 @SuppressFBWarnings
+@Getter
 public class CsvConverter {
     private SbomData sbomData;
     private Map<String, Component> componentMap;
-    static List<CsvData> dockerData;
-    static List<CsvData> vulnData;
+    private final List<CsvData> dockerData = new ArrayList<>();
+    private final List<CsvData> vulnData = new ArrayList<>();
 
     public CsvConverter(SbomData sbomData) {
         this.sbomData = sbomData;
         this.componentMap = populateComponentMap(sbomData);
-        dockerData = new ArrayList<>();
-        vulnData = new ArrayList<>();
     }
 
     Map<String, Component> populateComponentMap(SbomData sbomData) {

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParser.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParser.java
@@ -10,17 +10,14 @@ import lombok.Getter;
 import java.util.List;
 
 @SuppressFBWarnings
+@Getter
 public class SbomOutputParser {
-    @Getter
-    private SbomData sbom;
-    public static SeverityCounts vulnCounts;
-    public static SeverityCounts dockerCounts;
-    public static SeverityCounts aggregateCounts;
+    private final SbomData sbom;
+    private final SeverityCounts vulnCounts = new SeverityCounts();
+    private final SeverityCounts dockerCounts = new SeverityCounts();
+    private final SeverityCounts aggregateCounts = new SeverityCounts();
 
     public SbomOutputParser(SbomData sbomData) {
-        vulnCounts = new SeverityCounts();
-        dockerCounts = new SeverityCounts();
-        aggregateCounts = new SeverityCounts();
         this.sbom = sbomData;
     }
 

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverterTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverterTest.java
@@ -87,8 +87,22 @@ class CsvConverterTest {
         Component component = Component.builder().build();
         component.setPurl("InstalledVersion");
         csvConverter.routeVulnCsvData(vulnerability, component);
-        assertEquals(1, CsvConverter.vulnData.size());
-        assertEquals(0, CsvConverter.dockerData.size());
+        assertEquals(1, csvConverter.getVulnData().size());
+        assertEquals(0, csvConverter.getDockerData().size());
+    }
+
+    @Test
+    void parallelInstancesDoNotShareData() {
+        CsvConverter converterA = new CsvConverter(sbomData);
+        CsvConverter converterB = new CsvConverter(sbomData);
+
+        Vulnerability vulnerability = Vulnerability.builder().id("123").build();
+        Component component = Component.builder().build();
+        component.setPurl("InstalledVersion");
+        converterA.routeVulnCsvData(vulnerability, component);
+
+        assertEquals(1, converterA.getVulnData().size());
+        assertEquals(0, converterB.getVulnData().size());
     }
 
     @Test

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParserTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParserTest.java
@@ -41,6 +41,22 @@ class SbomOutputParserTest {
         severityCounts.increment(Severity.CRITICAL);
         SbomOutputParser parser = new SbomOutputParser(sbomData);
         parser.parseVulnCounts();
-        assertEquals(SbomOutputParser.aggregateCounts.getCounts(), severityCounts.getCounts());
+        assertEquals(parser.getAggregateCounts().getCounts(), severityCounts.getCounts());
+    }
+
+    @Test
+    void parallelInstancesDoNotShareCounters() {
+        SbomData sbomData = SbomData.builder().sbom(Sbom.builder().vulnerabilities(
+                List.of(Vulnerability.builder().id("CVE").ratings(
+                        List.of(Rating.builder().severity(Severity.CRITICAL.name()).build())
+                ).build())
+        ).build()).build();
+
+        SbomOutputParser parserA = new SbomOutputParser(sbomData);
+        SbomOutputParser parserB = new SbomOutputParser(sbomData);
+        parserA.parseVulnCounts();
+
+        assertEquals(1, parserA.getAggregateCounts().getCounts().get(Severity.CRITICAL));
+        assertEquals(0, parserB.getAggregateCounts().getCounts().get(Severity.CRITICAL));
     }
 }


### PR DESCRIPTION
### Problem

`SbomOutputParser` and `CsvConverter` hold their counters and CSV row lists in `public static` fields that get reset in the constructor. Since static fields are shared across the entire JVM, two builds running in parallel on the same Jenkins controller (multi-executor setups, pipeline `parallel { }` stages) overwrite each other's data, leading to wrong threshold decisions and corrupt CSV output.

### Fix

- Convert the static fields to `private final` instance fields with getters
- Update `AmazonInspectorBuilder.perform()` callsites and `filterSuppressedCvesFromCounts` to use the per-build parser instance

### Verification

- 72 unit tests pass (70 pre-existing + 2 new regression tests that prove two parser/converter instances don't share state)
- Live tested on Jenkins across 8 builds with different threshold scenarios — all results matched previous PR runs

<img width="1552" height="735" alt="image" src="https://github.com/user-attachments/assets/091ae4af-2213-4d9b-8ac1-7e454c62705d" />
