### PR TITLE
fix: misc code hygiene cleanup

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -2,7 +2,6 @@ package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.requests.SdkRequests;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Sbom;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
-import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Rating;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenDownloader;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -483,10 +482,8 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             throws IOException, InterruptedException {
         logger = listener.getLogger();
 
-        File outFile = new File(build.getRootDir(), "out");
         this.job = build.getParent();
 
-        PrintStream printStream = new PrintStream(outFile, StandardCharsets.UTF_8);
         try {
             if (showThresholdDeprecationWarning) {
                 listener.getLogger().println("[DEPRECATED] Parameter 'isThresholdEnabled' is deprecated. Use 'isSeverityThresholdEnabled' instead.");
@@ -728,12 +725,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
             listener.getLogger().println("Does Build Pass: " + doesBuildPass);
         } catch (Exception e) {
-            listener.getLogger().println("Plugin execution ran into an error and is being aborted!");
-            build.setResult(Result.ABORTED);
+            listener.getLogger().println("Plugin execution failed.");
+            build.setResult(Result.FAILURE);
             listener.getLogger().println("Exception:" + e);
             e.printStackTrace(listener.getLogger());
-        } finally {
-            printStream.close();
         }
     }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtils.java
@@ -8,7 +8,7 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Compone
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlJarHandler.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlJarHandler.java
@@ -1,11 +1,10 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.html;
 
-import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import lombok.AllArgsConstructor;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,12 +39,11 @@ public class HtmlJarHandler {
 
     @SuppressFBWarnings()
     public String readStringFromJarEntry(String fileName) throws IOException {
-        JarFile jarFile = new JarFile(jarPath);
-        JarEntry entry = jarFile.getJarEntry(fileName);
-        InputStream inputStream = jarFile.getInputStream(entry);
-        String content = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        inputStream.close();
-        jarFile.close();
-        return content;
+        try (JarFile jarFile = new JarFile(jarPath)) {
+            JarEntry entry = jarFile.getJarEntry(fileName);
+            try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            }
+        }
     }
 }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/DownloaderCallable.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/DownloaderCallable.java
@@ -28,39 +28,38 @@ class DownloaderCallable implements FilePath.FileCallable {
     @Override
     public String invoke(File f, VirtualChannel channel) throws IOException {
         byte[] buffer = new byte[1024];
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(f));
-        ZipEntry zipEntry = zis.getNextEntry();
         String sbomgenPath = "";
-        while (zipEntry != null) {
-            File newFile = newFile(new File(destinationPath), zipEntry);
-            if (zipEntry.getName().endsWith("inspector-sbomgen")) {
-                sbomgenPath = newFile.getAbsolutePath();
-                newFile.setExecutable(true);
-            }
-
-            if (zipEntry.isDirectory()) {
-                if (!newFile.isDirectory() && !newFile.mkdirs()) {
-                    throw new IOException("Failed to create directory " + newFile);
-                }
-            } else {
-                File parent = newFile.getParentFile();
-                if (!parent.isDirectory() && !parent.mkdirs()) {
-                    throw new IOException("Failed to create directory " + parent);
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(f))) {
+            ZipEntry zipEntry = zis.getNextEntry();
+            while (zipEntry != null) {
+                File newFile = newFile(new File(destinationPath), zipEntry);
+                if (zipEntry.getName().endsWith("inspector-sbomgen")) {
+                    sbomgenPath = newFile.getAbsolutePath();
+                    newFile.setExecutable(true);
                 }
 
-                FileOutputStream fos = new FileOutputStream(newFile);
-                int len;
-                while ((len = zis.read(buffer)) > 0) {
-                    fos.write(buffer, 0, len);
+                if (zipEntry.isDirectory()) {
+                    if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                        throw new IOException("Failed to create directory " + newFile);
+                    }
+                } else {
+                    File parent = newFile.getParentFile();
+                    if (!parent.isDirectory() && !parent.mkdirs()) {
+                        throw new IOException("Failed to create directory " + parent);
+                    }
+
+                    try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
+                    }
                 }
-                fos.close();
+                zipEntry = zis.getNextEntry();
             }
-            zipEntry = zis.getNextEntry();
+
+            zis.closeEntry();
         }
-
-        zis.closeEntry();
-        zis.close();
-
 
         return sbomgenPath;
     }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
@@ -16,14 +16,11 @@ import hudson.util.ArgumentListBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class SbomgenUtils {
 
     public static String processSbomgenOutput(String sbom) throws MalformedScanOutputException {
-        sbom.replaceAll("time=.+file=.+\"", "");
-
         int startIndex = sbom.indexOf("{");
         int endIndex = sbom.lastIndexOf("}");
 
@@ -39,14 +36,12 @@ public class SbomgenUtils {
     public static String stripProperties(String sbom) {
         JsonObject json = JsonParser.parseString(sbom).getAsJsonObject();
 
-        if (json == null || json.getAsJsonObject() == null || json.getAsJsonObject().get("components") == null) {
-            AmazonInspectorBuilder.logger.printf("Strip properties failed the null check. json: %s, jsonObject: %s, " +
-                            "components: %s%n", json == null, json.getAsJsonObject() == null,
-                    json.getAsJsonObject().get("components") == null);
+        if (json == null || json.get("components") == null) {
+            AmazonInspectorBuilder.logger.println("Strip properties failed the null check.");
             return sbom;
         }
 
-        JsonArray components = json.getAsJsonObject().get("components").getAsJsonArray();
+        JsonArray components = json.get("components").getAsJsonArray();
 
         for (JsonElement component : components) {
             component.getAsJsonObject().remove("properties");
@@ -69,6 +64,7 @@ public class SbomgenUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
@@ -24,8 +24,4 @@ public class Sanitizer {
         }
 
     }
-
-    public static String sanitizeText(String text) throws URISyntaxException {
-        return sanitizeFilePath(text);
-    }
 }

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
@@ -1,8 +1,12 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
-        
+
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.exception.MalformedScanOutputException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.amazon.inspector.jenkins.amazoninspectorbuildstep.exception.MalformedScanOutputException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.processSbomgenOutput;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.stripProperties;
@@ -10,6 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class SbomgenUtilsTest {
+
+    @BeforeEach
+    void setUp() {
+        AmazonInspectorBuilder.logger = new PrintStream(new ByteArrayOutputStream());
+    }
 
     @Test
     void testProcessSbomgenOutput() throws MalformedScanOutputException {
@@ -22,5 +31,10 @@ class SbomgenUtilsTest {
         String bom = "{\"components\": [{\"properties\": []}]}";
         assertFalse(stripProperties(bom).contains("\"properties\""));
     }
-}
 
+    @Test
+    void stripProperties_returnsInputWhenComponentsMissing() {
+        String bom = "{\"bomFormat\": \"CycloneDX\"}";
+        assertEquals(bom, stripProperties(bom));
+    }
+}

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
@@ -1,11 +1,8 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeFilePath;
-import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils.Sanitizer.sanitizeText;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SanitizerTest {
@@ -16,7 +13,7 @@ class SanitizerTest {
     }
 
     @Test
-    void testSanitizeNonUrl() throws URISyntaxException {
-        assertEquals("test:test%7B%7D", sanitizeText("test:test{}"));
+    void testSanitizeNonUrl() {
+        assertEquals("test:test%7B%7D", sanitizeFilePath("test:test{}"));
     }
 }


### PR DESCRIPTION
### Summary

Small mix of bug fixes, resource-leak fixes, and dead code removal across a few files.

### Changes

- **Outer catch returns `Result.FAILURE` instead of `Result.ABORTED`** in `perform()` — failed scans now correctly show as failed, not as user-cancelled
- **`SbomgenUtils.runCommand`** re-sets the thread interrupt flag when catching `InterruptedException` — restores Jenkins' ability to detect mid-build cancellation
- **`SbomgenUtils.stripProperties`** had a null guard that itself NPEs on null input — simplified to a correct guard
- **`SbomgenUtils.processSbomgenOutput`** had a `replaceAll` whose return value was thrown away (dead code, did nothing) — removed
- **`HtmlJarHandler.readStringFromJarEntry`** wraps `JarFile` and `InputStream` in try-with-resources — fixes a file handle leak if `IOUtils.toString` throws
- **`DownloaderCallable.invoke`** wraps `ZipInputStream` and `FileOutputStream` in try-with-resources — fixes a file handle leak during sbomgen extraction
- **`StringEscapeUtils`** swap from deprecated `org.apache.commons.lang3` to `org.apache.commons.text` (lang3 version is deprecated since 3.6)
- **Removed dead `out` PrintStream** in `perform()` — opened on every build, never written to, closed in `finally`
- **Removed dead `Sanitizer.sanitizeText`** shim that just delegated to `sanitizeFilePath`
- **Removed unused imports** (`Rating`, `HashMap`, `AmazonInspectorBuilder`, `MalformedURLException`)

### Verification

- 73 unit tests pass (1 new regression test for the `stripProperties` null guard)
- Built and tested live on Jenkins:
  - **Bogus image** → build correctly shows **FAILURE** with `Plugin execution failed.` (was ABORTED before)
  - **Normal scan** → SUCCESS, HTML report and CSV artifacts render correctly
  - **Mid-build cancellation** → ABORTED, cancellation propagates cleanly through `runCommand`

### Screenshots

**Test 1 — bogus image, build correctly fails:**
<!-- paste -->
<img width="1254" height="753" alt="Screenshot 2026-05-29 at 11 56 26 AM" src="https://github.com/user-attachments/assets/4ff92944-da2a-45ae-aa8a-d2052a4a7af0" />


**Test 2 — normal scan, artifacts intact:**
<!-- paste -->
<img width="1254" height="753" alt="Screenshot 2026-05-29 at 11 58 24 AM" src="https://github.com/user-attachments/assets/d8548c52-5465-42eb-977c-6a3dd9366557" />

**Test 3 — cancellation propagates:**
<!-- paste -->
<img width="1139" height="717" alt="image" src="https://github.com/user-attachments/assets/ccad218d-38bb-456e-9c8e-57b245f85e37" />
<img width="1175" height="779" alt="Screenshot 2026-05-29 at 12 01 20 PM" src="https://github.com/user-attachments/assets/102e9af7-4560-4365-9a46-12b4a30ec7fe" />

