### PR TITLE
fix: resolve SpotBugs violations and enforce in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,5 @@ jobs:
           java-version: 21
           cache: maven
 
-      - name: Run tests
-        run: mvn -B -ntp test
-
-      - name: Build plugin
-        run: mvn -B -ntp -DskipTests package
+      - name: Build and verify
+        run: mvn -B -ntp verify

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -862,7 +862,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                     Collections.emptyList()
             );
 
-            items.add("Select Docker Username", null);
+            items.add("Select Docker Username", "");
             for (StandardUsernamePasswordCredentials credential : credentials) {
                 if (credential.getUsername() != null && !credential.getUsername().isEmpty()) {
                     items.add(String.format("[%s] %s/*****", credential.getId(), credential.getUsername()),
@@ -906,11 +906,10 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         }
 
         @POST
-        @SuppressFBWarnings
         public ListBoxModel doFillOidcCredentialIdItems() {
             if (Jenkins.get().hasPermission(READ)) {
                 ListBoxModel items = new ListBoxModel();
-                items.add("Select OIDC Credential ID", null);
+                items.add("Select OIDC Credential ID", "");
                 items.addAll(getOidcFileIdModels());
                 items.addAll(getOidcStringIdModels());
                 return items;
@@ -1066,7 +1065,6 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             return FormValidation.ok();
         }
 
-        @SuppressFBWarnings()
         private ListBoxModel getAwsCredentialIdModels() {
             ListBoxModel items = new ListBoxModel();
             List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentialsInItemGroup(
@@ -1076,7 +1074,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                     Collections.emptyList()
             );
 
-            items.add("Select AWS Credentials", null);
+            items.add("Select AWS Credentials", "");
             for (AmazonWebServicesCredentials credential : credentials) {
                 if (credential != null && credential.getCredentials() != null) {
                     items.add(String.format("[%s] %s", credential.getId(), credential.getDisplayName()),
@@ -1098,7 +1096,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         public ListBoxModel doFillAwsRegionItems() {
             ListBoxModel items = new ListBoxModel();
 
-            items.add("Select AWS Region", null);
+            items.add("Select AWS Region", "");
 
             for (String region : INSPECTOR_REGIONS) {
                 items.add(region, region);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverter.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/csvconversion/CsvConverter.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.html.HtmlConversionUtils.getLineComponents;
 
-@SuppressFBWarnings
 @Getter
 public class CsvConverter {
     private SbomData sbomData;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlJarHandler.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlJarHandler.java
@@ -1,6 +1,5 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.html;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import lombok.AllArgsConstructor;
 import org.apache.commons.io.IOUtils;
@@ -37,7 +36,6 @@ public class HtmlJarHandler {
         return htmlContent;
     }
 
-    @SuppressFBWarnings()
     public String readStringFromJarEntry(String fileName) throws IOException {
         try (JarFile jarFile = new JarFile(jarPath)) {
             JarEntry entry = jarFile.getJarEntry(fileName);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/html/components/HtmlVulnerability.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/html/components/HtmlVulnerability.java
@@ -1,7 +1,10 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.html.components;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Builder;
 
+/** Fields are serialized by Gson into the HTML report; SpotBugs can't see that usage. */
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
 @Builder
 public class HtmlVulnerability {
     public String title;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/html/components/ImageMetadata.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/html/components/ImageMetadata.java
@@ -1,7 +1,10 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.html.components;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Builder;
 
+/** Fields are serialized by Gson into the HTML report; SpotBugs can't see that usage. */
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
 @Builder
 public class ImageMetadata {
     public String id;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -4,7 +4,7 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuil
 import com.google.common.annotations.VisibleForTesting;
 import hudson.FilePath;
 import hudson.Launcher;
-import lombok.Setter;
+import lombok.Getter;
 
 import java.io.File;
 import java.util.Arrays;
@@ -14,20 +14,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("lgtm[jenkins/plaintext-storage]")
+@Getter
 public class SbomgenRunner {
 
-    public String sbomgenPath;
-    public String archiveType;
-    public String archivePath;
-    public Launcher launcher;
-    public FilePath workspace;
-
-    @Setter
-    public String dockerUsername;
-
-    @Setter
-    public String dockerPassword;
-
+    private final String sbomgenPath;
+    private final String archiveType;
+    private final String archivePath;
+    private final Launcher launcher;
+    private final FilePath workspace;
+    private final String dockerUsername;
+    private final String dockerPassword;
     private final String sbomgenSkipFiles;
     private final boolean isLicenseCollectionEnabled;
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
@@ -32,7 +32,6 @@ public class SbomgenUtils {
     }
 
     @VisibleForTesting
-    @SuppressFBWarnings()
     public static String stripProperties(String sbom) {
         JsonObject json = JsonParser.parseString(sbom).getAsJsonObject();
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParser.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SbomOutputParser.java
@@ -4,12 +4,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Rating;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 
 import java.util.List;
 
-@SuppressFBWarnings
 @Getter
 public class SbomOutputParser {
     private final SbomData sbom;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SbomgenProcessing.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SbomgenProcessing.java
@@ -29,7 +29,10 @@ public class SbomgenProcessing {
     }
 
     public static String processSbomgenFile(File outFile) throws IOException {
-        String rawFileContent = new String(new FileInputStream(outFile).readAllBytes(), StandardCharsets.UTF_8);
+        String rawFileContent;
+        try (FileInputStream fis = new FileInputStream(outFile)) {
+            rawFileContent = new String(fis.readAllBytes(), StandardCharsets.UTF_8);
+        }
 
         String[] splitRawFileContent = rawFileContent.split("\n");
         List<String> lines = new ArrayList<>();

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunnerTest.java
@@ -71,7 +71,7 @@ class SbomgenRunnerTest {
         SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
         
         // Verify the runner correctly identifies remote agent scenario
-        assertNotNull(runner.workspace.getChannel(), "Should detect remote agent when workspace has channel");
+        assertNotNull(runner.getWorkspace().getChannel(), "Should detect remote agent when workspace has channel");
     }
 
     @Test
@@ -83,6 +83,6 @@ class SbomgenRunnerTest {
         SbomgenRunner runner = new SbomgenRunner(null, mockWorkspace, null, null, null, null, null, null, false);
 
         // Verify the runner correctly identifies local execution scenario
-        assertNull(runner.workspace.getChannel(), "Should detect local execution when workspace has no channel");
+        assertNull(runner.getWorkspace().getChannel(), "Should detect local execution when workspace has no channel");
     }
 }


### PR DESCRIPTION
## What

Fixed all 15 SpotBugs violations and flipped the CI workflow from `mvn test` + `mvn package` to a single `mvn verify` step so SpotBugs runs on every PR.

## Changes

**SpotBugs fixes**
- 4× dropdown placeholder values: `null` → `""` (Docker, OIDC, AWS Creds, AWS Region)
- `SbomgenRunner`: public mutable fields → private final + Lombok `@Getter`; removed `@Setter` since constructor already takes all values
- 2× targeted `@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")` on Gson-serialized DTOs (`HtmlVulnerability`, `ImageMetadata`) with a comment explaining why
- 5× useless `@SuppressFBWarnings` removed (`CsvConverter`, `SbomgenUtils.stripProperties`, `SbomOutputParser`, `HtmlJarHandler.readStringFromJarEntry`, two on `AmazonInspectorBuilder` dropdown methods)
- `SbomgenProcessing.processSbomgenFile`: wrapped `FileInputStream` in try-with-resources to fix the file-descriptor leak

**CI**
- `.github/workflows/build.yml`: replaced two-step `test` + `package` with single `mvn verify` so SpotBugs runs on every PR

## Tested

- `mvn verify` locally → BUILD SUCCESS, 73 tests pass, 0 SpotBugs violations
- Live verified in Jenkins:
  1. All 4 dropdowns still render their "Select X" placeholder correctly
  2. End-to-end scan on `ubuntu:18.04` → SUCCESS, HTML and CSV reports generated
<img width="2329" height="1305" alt="Screenshot 2026-06-02 at 10 25 22 AM" src="https://github.com/user-attachments/assets/53d6dedd-e323-4b73-a202-a20341acbe47" />
<img width="2329" height="1305" alt="Screenshot 2026-06-02 at 10 25 54 AM" src="https://github.com/user-attachments/assets/69cc6822-87aa-4fba-b19b-98216ef501e0" />
