### PR TITLE
fix: harden scan submission path and take safe dependency bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
     <extension>
         <groupId>io.jenkins.tools.incrementals</groupId>
         <artifactId>git-changelist-maven-extension</artifactId>
-        <version>1.8</version>
+        <version>1.13</version>
     </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.19.2-408.v18248a_324cfe</version>
+            <version>2.21.2-436.v29efdb_7418ff</version>
         </dependency>
 
         <dependency>
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.6</version>
                 <configuration>
                     <excludes>
                         <exclude>**InjectedTest</exclude>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequests.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequests.java
@@ -2,7 +2,7 @@ package com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.requests;
 
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -16,14 +16,13 @@ import software.amazon.awssdk.protocols.json.internal.unmarshall.document.Docume
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.inspectorscan.InspectorScanClient;
+import software.amazon.awssdk.services.inspectorscan.model.OutputFormat;
 import software.amazon.awssdk.services.inspectorscan.model.ScanSbomRequest;
 import software.amazon.awssdk.services.inspectorscan.model.ScanSbomResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-
-import software.amazon.awssdk.services.inspectorscan.model.OutputFormat;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 
 public class SdkRequests {
@@ -43,72 +42,93 @@ public class SdkRequests {
     }
 
     public String requestSbom(String sbom) {
-        SdkHttpClient client = ApacheHttpClient.builder().build();
         String workingProfileName = awsProfileName;
         AmazonWebServicesCredentials workingCredential = awsCredential;
         String workingOidc = oidc;
         boolean retry = true;
 
-        while (true) {
-            try {
-                InspectorScanClient scanClient = InspectorScanClient.builder()
-                        .region(Region.of(region))
-                        .httpClient(client)
-                        .credentialsProvider(getCredentialProvider(workingProfileName, workingOidc, workingCredential))
-                        .overrideConfiguration(ClientOverrideConfiguration.builder()
-                        .putHeader("Accept-Encoding", "gzip")
-                        .build())
-                        .build();
+        try (SdkHttpClient client = buildHttpClient()) {
+            while (true) {
+                try (InspectorScanClient scanClient =
+                             buildScanClient(client, workingProfileName, workingOidc, workingCredential)) {
 
-                JsonNodeParser jsonNodeParser = JsonNodeParser.create();
-                DocumentUnmarshaller unmarshaller = new DocumentUnmarshaller();
-                Document document = jsonNodeParser.parse(sbom).visit(unmarshaller);
+                    JsonNodeParser jsonNodeParser = JsonNodeParser.create();
+                    DocumentUnmarshaller unmarshaller = new DocumentUnmarshaller();
+                    Document document = jsonNodeParser.parse(sbom).visit(unmarshaller);
 
-                ScanSbomRequest request = ScanSbomRequest.builder()
-                        .sbom(document)
-                        .outputFormat(OutputFormat.CYCLONE_DX_1_5)
-                        .build();
-                ScanSbomResponse response = scanClient.scanSbom(request);
-                return response.sbom().toString();
-            } catch (Exception e) {
-                AmazonInspectorBuilder.logger.println(e);
-                if (!retry) {
-                    throw e;
+                    ScanSbomRequest request = ScanSbomRequest.builder()
+                            .sbom(document)
+                            .outputFormat(OutputFormat.CYCLONE_DX_1_5)
+                            .build();
+                    ScanSbomResponse response = scanClient.scanSbom(request);
+                    return response.sbom().toString();
+                } catch (Exception e) {
+                    e.printStackTrace(AmazonInspectorBuilder.logger);
+                    if (!retry) {
+                        throw e;
+                    }
+
+                    retry = false;
+                    AmazonInspectorBuilder.logger.println("An issue occurred while authenticating, attempting to " +
+                            "authenticate with default credential provider chain");
+                    workingProfileName = "default";
+                    workingCredential = null;
+                    workingOidc = null;
                 }
-
-                retry = false;
-                AmazonInspectorBuilder.logger.println("An issue occurred while authenticating, attempting to " +
-                        "authenticate with default credential provider chain");
-                workingProfileName = "default";
-                workingCredential = null;
-                workingOidc = null;
             }
         }
     }
 
-    @SuppressFBWarnings
-    private AwsCredentialsProvider getCredentialProvider(String workingProfileName, String workingOidc,
-                                                         AmazonWebServicesCredentials workingCredential) {
-        StsClient stsClient = StsClient.builder().region(Region.of(region)).build();
+    @VisibleForTesting
+    SdkHttpClient buildHttpClient() {
+        return ApacheHttpClient.builder().build();
+    }
+
+    @VisibleForTesting
+    InspectorScanClient buildScanClient(SdkHttpClient client, String workingProfileName, String workingOidc,
+                                        AmazonWebServicesCredentials workingCredential) {
+        return InspectorScanClient.builder()
+                .region(Region.of(region))
+                .httpClient(client)
+                .credentialsProvider(getCredentialProvider(workingProfileName, workingOidc, workingCredential))
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .putHeader("Accept-Encoding", "gzip")
+                        .build())
+                .build();
+    }
+
+    @VisibleForTesting
+    AwsCredentialsProvider getCredentialProvider(String workingProfileName, String workingOidc,
+                                                 AmazonWebServicesCredentials workingCredential) {
         if (workingCredential != null) {
             AmazonInspectorBuilder.logger.println("Using explicitly provided AWS credentials to authenticate.");
-            return StaticCredentialsProvider.create(createRawCredentialProvider(workingCredential).resolveCredentials());
+            return StaticCredentialsProvider.create(
+                    createRawCredentialProvider(workingCredential).resolveCredentials());
         } else if (roleArn != null && !roleArn.isEmpty() && workingOidc != null && !workingOidc.isEmpty()) {
             AmazonInspectorBuilder.logger.println("Using OAuth token and role to authenticate.");
-            stsClient = StsClient.builder().credentialsProvider(createRawCredentialProvider(workingCredential))
-                    .region(Region.of(region)).build();
+            // No credentials provider needed: AssumeRoleWithWebIdentity is an unsigned STS call.
+            StsClient stsClient = StsClient.builder()
+                    .region(Region.of(region))
+                    .build();
             AssumeRoleWithWebIdentityRequest webIdentityRequest = AssumeRoleWithWebIdentityRequest.builder()
                     .roleArn(roleArn)
                     .roleSessionName("inspectorscan")
                     .webIdentityToken(workingOidc)
                     .build();
-            stsClient.assumeRoleWithWebIdentity(webIdentityRequest);
-            return StsAssumeRoleWithWebIdentityCredentialsProvider.builder().stsClient(stsClient).refreshRequest(webIdentityRequest).build();
+            return StsAssumeRoleWithWebIdentityCredentialsProvider.builder()
+                    .stsClient(stsClient)
+                    .refreshRequest(webIdentityRequest)
+                    .build();
         } else if (roleArn != null && !roleArn.isEmpty()) {
             AmazonInspectorBuilder.logger.println("Authenticating to STS via a role and default credential provider chain.");
-
-            return StsAssumeRoleCredentialsProvider.builder().stsClient(stsClient).refreshRequest(AssumeRoleRequest.builder()
-                    .roleArn(roleArn).roleSessionName("inspectorscan").build()).build();
+            StsClient stsClient = StsClient.builder().region(Region.of(region)).build();
+            return StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(stsClient)
+                    .refreshRequest(AssumeRoleRequest.builder()
+                            .roleArn(roleArn)
+                            .roleSessionName("inspectorscan")
+                            .build())
+                    .build();
         } else if (workingProfileName != null && !workingProfileName.isEmpty()) {
             AmazonInspectorBuilder.logger.println(
                     String.format("AWS Credential and role not provided, authenticating using \"%s\" as profile name.",

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -59,7 +59,9 @@ public class SbomgenDownloader {
 
     private static FilePath downloadFile(String url, FilePath workspace) throws IOException, InterruptedException {
         FilePath sbomgenZip = workspace.child("inspector-sbomgen.zip");
-        sbomgenZip.copyFrom(new BufferedInputStream(new URL(url).openStream()));
+        try (BufferedInputStream in = new BufferedInputStream(new URL(url).openStream())) {
+            sbomgenZip.copyFrom(in);
+        }
         return sbomgenZip;
     }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
@@ -16,6 +16,9 @@ public class Sanitizer {
     public static String sanitizeFilePath(String rawUrl) {
         try {
             String[] splitUrl = rawUrl.split(":");
+            if (splitUrl.length < 2) {
+                return rawUrl;
+            }
             URI uri = new URI(splitUrl[0], splitUrl[1], null);
             return uri.toASCIIString();
         } catch(Exception e) {

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequestsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequestsTest.java
@@ -1,0 +1,171 @@
+package com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.requests;
+
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
+import com.amazonaws.auth.AWSCredentials;
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.inspectorscan.InspectorScanClient;
+import software.amazon.awssdk.services.inspectorscan.model.ScanSbomRequest;
+import software.amazon.awssdk.services.inspectorscan.model.ScanSbomResponse;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCredentialsProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SdkRequestsTest {
+
+    @BeforeEach
+    void setUp() {
+        AmazonInspectorBuilder.logger = new PrintStream(new ByteArrayOutputStream());
+    }
+
+    @Test
+    void getCredentialProvider_withExplicitCredential_usesStaticProvider() {
+        AWSCredentials raw = mock(AWSCredentials.class);
+        when(raw.getAWSAccessKeyId()).thenReturn("AKIAEXAMPLE");
+        when(raw.getAWSSecretKey()).thenReturn("secretExample");
+
+        AmazonWebServicesCredentials credential = mock(AmazonWebServicesCredentials.class);
+        when(credential.getCredentials()).thenReturn(raw);
+
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", credential, null, null, null);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider(null, null, credential);
+
+        assertInstanceOf(StaticCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void getCredentialProvider_withProfileName_usesProfileProvider() {
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", null, null, "my-profile", null);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider("my-profile", null, null);
+
+        assertInstanceOf(ProfileCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void getCredentialProvider_withNothingProvided_usesDefaultChain() {
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", null, null, null, null);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider(null, null, null);
+
+        assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void getCredentialProvider_withRoleArnOnly_usesAssumeRoleProvider() {
+        String roleArn = "arn:aws:iam::123456789012:role/inspector";
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", null, null, null, roleArn);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider(null, null, null);
+
+        assertInstanceOf(StsAssumeRoleCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void getCredentialProvider_withRoleArnAndOidc_usesWebIdentityProvider() {
+        String roleArn = "arn:aws:iam::123456789012:role/inspector";
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", null, "oidc-token", null, roleArn);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider(null, "oidc-token", null);
+
+        assertInstanceOf(StsAssumeRoleWithWebIdentityCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void getCredentialProvider_emptyProfileName_fallsBackToDefaultChain() {
+        SdkRequests sdkRequests = new SdkRequests("us-east-1", null, null, "", null);
+
+        AwsCredentialsProvider provider = sdkRequests.getCredentialProvider("", null, null);
+
+        assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    }
+
+    @Test
+    void requestSbom_onSuccess_returnsSbomAndClosesClients() {
+        SdkHttpClient httpClient = mock(SdkHttpClient.class);
+        InspectorScanClient scanClient = mock(InspectorScanClient.class);
+        ScanSbomResponse response = mock(ScanSbomResponse.class);
+        when(response.sbom()).thenReturn(software.amazon.awssdk.core.document.Document.fromString("scanned"));
+        when(scanClient.scanSbom(any(ScanSbomRequest.class))).thenReturn(response);
+
+        SdkRequests sdkRequests = spy(new SdkRequests("us-east-1", null, null, null, null));
+        doReturn(httpClient).when(sdkRequests).buildHttpClient();
+        doReturn(scanClient).when(sdkRequests).buildScanClient(eq(httpClient), any(), any(), any());
+
+        String result = sdkRequests.requestSbom("{\"bomFormat\":\"CycloneDX\"}");
+
+        assertEquals("\"scanned\"", result);
+        // Both the shared HTTP client and the per-attempt scan client must be closed.
+        verify(httpClient).close();
+        verify(scanClient).close();
+        // Success on first attempt: only one scan client is built.
+        verify(sdkRequests, times(1)).buildScanClient(any(), any(), any(), any());
+    }
+
+    @Test
+    void requestSbom_firstAttemptFails_retriesOnceThenSucceeds() {
+        SdkHttpClient httpClient = mock(SdkHttpClient.class);
+        InspectorScanClient failingClient = mock(InspectorScanClient.class);
+        InspectorScanClient succeedingClient = mock(InspectorScanClient.class);
+        when(failingClient.scanSbom(any(ScanSbomRequest.class)))
+                .thenThrow(new RuntimeException("auth failure"));
+        ScanSbomResponse response = mock(ScanSbomResponse.class);
+        when(response.sbom()).thenReturn(software.amazon.awssdk.core.document.Document.fromString("recovered"));
+        when(succeedingClient.scanSbom(any(ScanSbomRequest.class))).thenReturn(response);
+
+        SdkRequests sdkRequests = spy(new SdkRequests("us-east-1", null, null, "explicit-profile", null));
+        doReturn(httpClient).when(sdkRequests).buildHttpClient();
+        doReturn(failingClient).doReturn(succeedingClient)
+                .when(sdkRequests).buildScanClient(eq(httpClient), any(), any(), any());
+
+        String result = sdkRequests.requestSbom("{\"bomFormat\":\"CycloneDX\"}");
+
+        assertEquals("\"recovered\"", result);
+        // Two attempts: the failing client and the recovering client are both built and closed.
+        verify(sdkRequests, times(2)).buildScanClient(any(), any(), any(), any());
+        verify(failingClient).close();
+        verify(succeedingClient).close();
+        verify(httpClient).close();
+    }
+
+    @Test
+    void requestSbom_bothAttemptsFail_rethrowsAndClosesClients() {
+        SdkHttpClient httpClient = mock(SdkHttpClient.class);
+        InspectorScanClient scanClient = mock(InspectorScanClient.class);
+        when(scanClient.scanSbom(any(ScanSbomRequest.class)))
+                .thenThrow(new RuntimeException("persistent failure"));
+
+        SdkRequests sdkRequests = spy(new SdkRequests("us-east-1", null, null, null, null));
+        doReturn(httpClient).when(sdkRequests).buildHttpClient();
+        doReturn(scanClient).when(sdkRequests).buildScanClient(eq(httpClient), any(), any(), any());
+
+        assertThrows(RuntimeException.class,
+                () -> sdkRequests.requestSbom("{\"bomFormat\":\"CycloneDX\"}"));
+
+        // One retry then give up: exactly two attempts, all clients closed even on failure.
+        verify(sdkRequests, times(2)).buildScanClient(any(), any(), any(), any());
+        verify(scanClient, times(2)).close();
+        verify(httpClient).close();
+    }
+}

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/SanitizerTest.java
@@ -16,4 +16,16 @@ class SanitizerTest {
     void testSanitizeNonUrl() {
         assertEquals("test:test%7B%7D", sanitizeFilePath("test:test{}"));
     }
+
+    @Test
+    void testSanitizeFilePathWithoutColon() {
+        // No colon: returned as-is instead of throwing ArrayIndexOutOfBoundsException.
+        assertEquals("/var/lib/jenkins/workspace/image.tar",
+                sanitizeFilePath("/var/lib/jenkins/workspace/image.tar"));
+    }
+
+    @Test
+    void testSanitizeEmptyString() {
+        assertEquals("", sanitizeFilePath(""));
+    }
 }


### PR DESCRIPTION
## What

Hardens the scan-submission and binary-download path, and pulls in the current open Dependabot bumps.

## Scan-path fixes

- **SdkRequests**: wrapped the HTTP client and Inspector scan client in try-with-resources to fix connection-pool leaks on every scan; removed a dead `assumeRoleWithWebIdentity()` call whose result was discarded (one fewer STS round-trip per OIDC scan); removed a latent NPE in the OIDC branch (the STS client was built with an always-null credentials provider); switched `logger.println(e)` to `e.printStackTrace(logger)` so failed scans show a full stack trace.
- **SbomgenDownloader**: wrapped the sbomgen download stream in try-with-resources.
- **Sanitizer**: guarded `sanitizeFilePath` against an `ArrayIndexOutOfBoundsException` on paths with no colon.

## Dependency bumps

Takes all open Dependabot PRs:
- jackson2-api 2.19.2 → 2.21.2 (#194) — aligns with jackson-databind already at 2.21.2
- maven-surefire-plugin 3.5.4 → 3.5.6 (#195)
- git-changelist-maven-extension 1.8 → 1.13 (#192)
- actions/checkout 4 → 6 (#190)
- actions/setup-java 4 → 5 (#189)

## Tests

- 84 tests pass (added 9 for SdkRequests: credential-provider selection across all 5 auth paths, plus retry and resource-cleanup behavior; added 2 for Sanitizer)
- `mvn verify` clean, 0 SpotBugs violations
- Live verified in Jenkins: plugin loads enabled, clean restart with no classloader errors, end-to-end `ubuntu:18.04` scan SUCCESS, HTML + CSV + SBOM reports generated
<img width="2524" height="271" alt="Screenshot 2026-06-02 at 12 28 07 PM" src="https://github.com/user-attachments/assets/a7b1908e-b000-4b56-8910-c0687782ce20" />
<img width="2358" height="1346" alt="Screenshot 2026-06-02 at 12 27 08 PM" src="https://github.com/user-attachments/assets/56edc3be-5dcc-4b19-8383-0599fd389d64" />
<img width="2524" height="1020" alt="Screenshot 2026-06-02 at 12 30 05 PM" src="https://github.com/user-attachments/assets/6a196994-290a-4e98-81f4-da0f2f9ba4f1" />
<img width="2524" height="1020" alt="Screenshot 2026-06-02 at 12 30 46 PM" src="https://github.com/user-attachments/assets/4794069d-c9d0-4911-9164-4232e8bfc1a9" />


