### PR TITLE
fix: make per-build logger thread-safe with ThreadLocal

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -6,6 +6,7 @@ import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenDown
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -69,8 +70,28 @@ import static hudson.security.Permission.READ;
 
 @Getter
 public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
-    @SuppressFBWarnings()
-    public static PrintStream logger;
+    /**
+     * Per-build console logger. ThreadLocal (not a plain static field) so concurrent builds, which
+     * run on separate executor threads, don't overwrite each other's stream. Cleared in perform()'s
+     * finally block so a pooled thread doesn't retain a finished build's stream.
+     */
+    private static final ThreadLocal<PrintStream> LOGGER_HOLDER = new ThreadLocal<>();
+
+    /** Console logger for the current build thread, or System.out if called outside a build. */
+    public static PrintStream getLogger() {
+        PrintStream current = LOGGER_HOLDER.get();
+        return current != null ? current : System.out;
+    }
+
+    @VisibleForTesting
+    public static void setLogger(PrintStream logger) {
+        LOGGER_HOLDER.set(logger);
+    }
+
+    @VisibleForTesting
+    public static void clearLogger() {
+        LOGGER_HOLDER.remove();
+    }
     
     private static final int MAX_BLOCKED_CVES_CONSOLE = 20;
     private static final int MAX_IGNORED_CVES_CONSOLE = 10;
@@ -480,7 +501,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
     @Override
     public void perform(Run<?, ?> build, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException {
-        logger = listener.getLogger();
+        setLogger(listener.getLogger());
 
         this.job = build.getParent();
 
@@ -507,7 +528,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
             String activeSbomgenPath;
             if ("automatic".equalsIgnoreCase(sbomgenSelection)) {
-                logger.println("Automatic SBOMGen selected, downloading using default settings...");
+                getLogger().println("Automatic SBOMGen selected, downloading using default settings...");
                 activeSbomgenPath = SbomgenDownloader.getBinary(workspace, env, launcher);
             } else if ("manual".equalsIgnoreCase(sbomgenSelection)) {
                 if (sbomgenPath == null || sbomgenPath.isEmpty()) {
@@ -517,16 +538,16 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 if (!sbomgenFile.exists() || !sbomgenFile.canExecute()) {
                     throw new IllegalArgumentException("Provided SBOMgen path is invalid or not executable: " + sbomgenPath);
                 }
-                logger.println("Manual SBOMGen selected, using provided path: " + sbomgenPath);
+                getLogger().println("Manual SBOMGen selected, using provided path: " + sbomgenPath);
                 activeSbomgenPath = sbomgenPath;
             } else {
-                logger.println("Invalid SBOMGen selection. Defaulting to Automatic.");
+                getLogger().println("Invalid SBOMGen selection. Defaulting to Automatic.");
                 activeSbomgenPath = SbomgenDownloader.getBinary(workspace, env, launcher);
             }
 
             StandardUsernamePasswordCredentials credential = null;
             if (credentialId == null) {
-                logger.println("Credential ID is null, this is not normal, please check your config. " +
+                getLogger().println("Credential ID is null, this is not normal, please check your config. " +
                         "Continuing without docker credentials.");
             } else {
                 credential = CredentialsProvider.findCredentialById(credentialId,
@@ -601,7 +622,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                     build.getDisplayName()).replaceAll("[ #]", "");
             String csvDockerWorkspacePath = String.format("%s/%s", build.getId(), csvDockerFileName);
             FilePath csvDockerFile = workspace.child(csvDockerWorkspacePath);
-            logger.println("Converting SBOM Results to CSV.");
+            getLogger().println("Converting SBOM Results to CSV.");
 
             SbomOutputParser parser = new SbomOutputParser(sbomData);
             parser.parseVulnCounts();
@@ -729,6 +750,8 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             build.setResult(Result.FAILURE);
             listener.getLogger().println("Exception:" + e);
             e.printStackTrace(listener.getLogger());
+        } finally {
+            clearLogger();
         }
     }
 
@@ -817,8 +840,8 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 }
             }
         } catch (Exception e) {
-            AmazonInspectorBuilder.logger.println("An exception occurred when getting image sha.");
-            AmazonInspectorBuilder.logger.println(e);
+            AmazonInspectorBuilder.getLogger().println("An exception occurred when getting image sha.");
+            e.printStackTrace(AmazonInspectorBuilder.getLogger());
         }
 
         return "N/A";

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequests.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequests.java
@@ -63,13 +63,13 @@ public class SdkRequests {
                     ScanSbomResponse response = scanClient.scanSbom(request);
                     return response.sbom().toString();
                 } catch (Exception e) {
-                    e.printStackTrace(AmazonInspectorBuilder.logger);
+                    e.printStackTrace(AmazonInspectorBuilder.getLogger());
                     if (!retry) {
                         throw e;
                     }
 
                     retry = false;
-                    AmazonInspectorBuilder.logger.println("An issue occurred while authenticating, attempting to " +
+                    AmazonInspectorBuilder.getLogger().println("An issue occurred while authenticating, attempting to " +
                             "authenticate with default credential provider chain");
                     workingProfileName = "default";
                     workingCredential = null;
@@ -101,11 +101,11 @@ public class SdkRequests {
     AwsCredentialsProvider getCredentialProvider(String workingProfileName, String workingOidc,
                                                  AmazonWebServicesCredentials workingCredential) {
         if (workingCredential != null) {
-            AmazonInspectorBuilder.logger.println("Using explicitly provided AWS credentials to authenticate.");
+            AmazonInspectorBuilder.getLogger().println("Using explicitly provided AWS credentials to authenticate.");
             return StaticCredentialsProvider.create(
                     createRawCredentialProvider(workingCredential).resolveCredentials());
         } else if (roleArn != null && !roleArn.isEmpty() && workingOidc != null && !workingOidc.isEmpty()) {
-            AmazonInspectorBuilder.logger.println("Using OAuth token and role to authenticate.");
+            AmazonInspectorBuilder.getLogger().println("Using OAuth token and role to authenticate.");
             // No credentials provider needed: AssumeRoleWithWebIdentity is an unsigned STS call.
             StsClient stsClient = StsClient.builder()
                     .region(Region.of(region))
@@ -120,7 +120,7 @@ public class SdkRequests {
                     .refreshRequest(webIdentityRequest)
                     .build();
         } else if (roleArn != null && !roleArn.isEmpty()) {
-            AmazonInspectorBuilder.logger.println("Authenticating to STS via a role and default credential provider chain.");
+            AmazonInspectorBuilder.getLogger().println("Authenticating to STS via a role and default credential provider chain.");
             StsClient stsClient = StsClient.builder().region(Region.of(region)).build();
             return StsAssumeRoleCredentialsProvider.builder()
                     .stsClient(stsClient)
@@ -130,13 +130,13 @@ public class SdkRequests {
                             .build())
                     .build();
         } else if (workingProfileName != null && !workingProfileName.isEmpty()) {
-            AmazonInspectorBuilder.logger.println(
+            AmazonInspectorBuilder.getLogger().println(
                     String.format("AWS Credential and role not provided, authenticating using \"%s\" as profile name.",
                             workingProfileName)
             );
             return ProfileCredentialsProvider.builder().profileName(workingProfileName).build();
         } else {
-            AmazonInspectorBuilder.logger.println("Using default credential provider chain to authenticate.");
+            AmazonInspectorBuilder.getLogger().println("Using default credential provider chain to authenticate.");
             return DefaultCredentialsProvider.create();
         }
     }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -7,7 +7,7 @@ import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder.logger;
+import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder.getLogger;
 
 public class SbomgenDownloader {
     private static final String BASE_URL = "https://amazon-inspector-" +
@@ -20,7 +20,7 @@ public class SbomgenDownloader {
 
     public static String getUrl(FilePath workspace, hudson.EnvVars env, hudson.Launcher launcher) throws IOException, InterruptedException {
         String osName = System.getProperty("os.name").toLowerCase();
-        logger.println("Detected OS Name: " + osName);
+        getLogger().println("Detected OS Name: " + osName);
         if (!osName.contains("linux")) {
             throw new UnsupportedOperationException("Unsupported OS: " + osName);
         }
@@ -35,17 +35,17 @@ public class SbomgenDownloader {
                 String output = SbomgenUtils.runCommand(new String[]{"uname", "-m"}, launcher, environment);
                 if (output != null && !output.trim().isEmpty()) {
                     osArch = output.trim();
-                    logger.println("Detected OS Architecture (from agent): " + osArch);
+                    getLogger().println("Detected OS Architecture (from agent): " + osArch);
                 }
             } catch (Exception e) {
-                logger.println("Failed to detect architecture from agent: " + e.getMessage());
+                getLogger().println("Failed to detect architecture from agent: " + e.getMessage());
             }
         }
         
         // Fallback to System.getProperty if agent detection failed
         if (osArch == null || osArch.trim().isEmpty()) {
             osArch = System.getProperty("os.arch").toLowerCase();
-            logger.println("Detected OS Architecture (fallback from master): " + osArch);
+            getLogger().println("Detected OS Architecture (fallback from master): " + osArch);
         }
         
         osArch = osArch.toLowerCase().trim();

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -63,11 +63,11 @@ public class SbomgenRunner {
             environment.put("INSPECTOR_SBOMGEN_PASSWORD", dockerPassword);
         }
 
-        AmazonInspectorBuilder.logger.println("Making downloaded SBOMGen executable...");
+        AmazonInspectorBuilder.getLogger().println("Making downloaded SBOMGen executable...");
         SbomgenUtils.runCommand(new String[]{"chmod", "+x", sbomgenFilePath.getRemote()},
                 launcher, environment);
 
-        AmazonInspectorBuilder.logger.println("Running command...");
+        AmazonInspectorBuilder.getLogger().println("Running command...");
         String option = "--image";
         if (!archiveType.equals("container")) {
             option = "--path";
@@ -80,7 +80,7 @@ public class SbomgenRunner {
                 archivePath
         };
 
-        AmazonInspectorBuilder.logger.println(Arrays.toString(baseCommandList));
+        AmazonInspectorBuilder.getLogger().println(Arrays.toString(baseCommandList));
 
         if (sbomgenSkipFiles != null && !sbomgenSkipFiles.trim().isEmpty()) {
             String[] patterns = sbomgenSkipFiles.split("\\r?\\n");
@@ -97,9 +97,9 @@ public class SbomgenRunner {
                 extendedCommandList[extendedCommandList.length - 1] = skipFilesJoined;
                 baseCommandList = extendedCommandList;
 
-                AmazonInspectorBuilder.logger.println("DEBUG: --skip-files argument: " +
+                AmazonInspectorBuilder.getLogger().println("DEBUG: --skip-files argument: " +
                         skipFilesJoined);
-                AmazonInspectorBuilder.logger.println(Arrays.toString(baseCommandList));
+                AmazonInspectorBuilder.getLogger().println(Arrays.toString(baseCommandList));
             }
         }
 
@@ -109,8 +109,8 @@ public class SbomgenRunner {
             extendedCommandList[extendedCommandList.length - 1] = "--collect-licenses";
             baseCommandList = extendedCommandList;
 
-            AmazonInspectorBuilder.logger.println("License collection enabled, adding --collect-licenses flag");
-            AmazonInspectorBuilder.logger.println(Arrays.toString(baseCommandList));
+            AmazonInspectorBuilder.getLogger().println("License collection enabled, adding --collect-licenses flag");
+            AmazonInspectorBuilder.getLogger().println(Arrays.toString(baseCommandList));
         }
 
         String output = SbomgenUtils.runCommand(baseCommandList, launcher, environment);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.exception.MalformedScanOutputException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.util.ArgumentListBuilder;
@@ -36,7 +35,7 @@ public class SbomgenUtils {
         JsonObject json = JsonParser.parseString(sbom).getAsJsonObject();
 
         if (json == null || json.get("components") == null) {
-            AmazonInspectorBuilder.logger.println("Strip properties failed the null check.");
+            AmazonInspectorBuilder.getLogger().println("Strip properties failed the null check.");
             return sbom;
         }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/Sanitizer.java
@@ -22,7 +22,7 @@ public class Sanitizer {
             URI uri = new URI(splitUrl[0], splitUrl[1], null);
             return uri.toASCIIString();
         } catch(Exception e) {
-            AmazonInspectorBuilder.logger.printf("%s in invalid format, using it as the path.", rawUrl);
+            AmazonInspectorBuilder.getLogger().printf("%s in invalid format, using it as the path.", rawUrl);
             return rawUrl;
         }
 

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderLoggerTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilderLoggerTest.java
@@ -1,0 +1,110 @@
+package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AmazonInspectorBuilderLoggerTest {
+
+    @AfterEach
+    void tearDown() {
+        AmazonInspectorBuilder.clearLogger();
+    }
+
+    @Test
+    void getLogger_withoutSet_fallsBackToSystemOut() {
+        AmazonInspectorBuilder.clearLogger();
+        assertSame(System.out, AmazonInspectorBuilder.getLogger(),
+                "Logging outside an active build should fall back to System.out, not throw or return null");
+    }
+
+    @Test
+    void setLogger_thenGetLogger_returnsSameStream() {
+        PrintStream stream = new PrintStream(new ByteArrayOutputStream());
+        AmazonInspectorBuilder.setLogger(stream);
+        assertSame(stream, AmazonInspectorBuilder.getLogger());
+    }
+
+    @Test
+    void clearLogger_revertsToSystemOut() {
+        AmazonInspectorBuilder.setLogger(new PrintStream(new ByteArrayOutputStream()));
+        AmazonInspectorBuilder.clearLogger();
+        assertSame(System.out, AmazonInspectorBuilder.getLogger());
+    }
+
+    /**
+     * Reproduces the concurrent-build scenario: two threads each set their own logger and write to
+     * it. With a plain static field the writes would interleave into a single stream; with the
+     * ThreadLocal each thread only ever sees its own stream.
+     */
+    @Test
+    void concurrentBuilds_doNotShareLoggerState() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            ByteArrayOutputStream bufferA = new ByteArrayOutputStream();
+            ByteArrayOutputStream bufferB = new ByteArrayOutputStream();
+            PrintStream streamA = new PrintStream(bufferA, true, StandardCharsets.UTF_8);
+            PrintStream streamB = new PrintStream(bufferB, true, StandardCharsets.UTF_8);
+
+            CountDownLatch bothAssigned = new CountDownLatch(2);
+            CountDownLatch done = new CountDownLatch(2);
+            AtomicReference<PrintStream> seenByA = new AtomicReference<>();
+            AtomicReference<PrintStream> seenByB = new AtomicReference<>();
+
+            pool.submit(() -> {
+                AmazonInspectorBuilder.setLogger(streamA);
+                bothAssigned.countDown();
+                try {
+                    // Wait until the other thread has also set its logger, maximizing the chance a
+                    // shared static field would be observed cross-thread.
+                    bothAssigned.await(5, TimeUnit.SECONDS);
+                    AmazonInspectorBuilder.getLogger().print("A");
+                    seenByA.set(AmazonInspectorBuilder.getLogger());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    AmazonInspectorBuilder.clearLogger();
+                    done.countDown();
+                }
+            });
+
+            pool.submit(() -> {
+                AmazonInspectorBuilder.setLogger(streamB);
+                bothAssigned.countDown();
+                try {
+                    bothAssigned.await(5, TimeUnit.SECONDS);
+                    AmazonInspectorBuilder.getLogger().print("B");
+                    seenByB.set(AmazonInspectorBuilder.getLogger());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    AmazonInspectorBuilder.clearLogger();
+                    done.countDown();
+                }
+            });
+
+            assertTrue(done.await(10, TimeUnit.SECONDS), "Both build threads should finish");
+
+            // Each thread saw exactly its own stream...
+            assertSame(streamA, seenByA.get());
+            assertSame(streamB, seenByB.get());
+            // ...and each stream received only its own thread's output, no cross-talk.
+            assertEquals("A", bufferA.toString(StandardCharsets.UTF_8));
+            assertEquals("B", bufferB.toString(StandardCharsets.UTF_8));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequestsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/models/requests/SdkRequestsTest.java
@@ -35,7 +35,7 @@ class SdkRequestsTest {
 
     @BeforeEach
     void setUp() {
-        AmazonInspectorBuilder.logger = new PrintStream(new ByteArrayOutputStream());
+        AmazonInspectorBuilder.setLogger(new PrintStream(new ByteArrayOutputStream()));
     }
 
     @Test

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtilsTest.java
@@ -17,7 +17,7 @@ class SbomgenUtilsTest {
 
     @BeforeEach
     void setUp() {
-        AmazonInspectorBuilder.logger = new PrintStream(new ByteArrayOutputStream());
+        AmazonInspectorBuilder.setLogger(new PrintStream(new ByteArrayOutputStream()));
     }
 
     @Test


### PR DESCRIPTION
## What

The plugin's console logger was a single `public static PrintStream` reassigned at the start of every `perform()`. Because a Jenkins controller runs concurrent builds on separate executor threads, two scans running at once would overwrite each other's logger — causing console output to interleave between builds or write to an already-closed stream.

This moves the logger into a `ThreadLocal` so each build thread gets its own stream, accessed via `getLogger()`. It's set at the start of `perform()` and cleared in a `finally` block so the pooled executor thread doesn't retain a finished build's stream.

## Changes

- `AmazonInspectorBuilder`: replaced `public static PrintStream logger` with a `ThreadLocal<PrintStream>` plus `getLogger()` (falls back to `System.out` when unset), `setLogger()`, and `clearLogger()`; added `clearLogger()` in the `perform()` finally block
- Migrated all logger call sites to `getLogger()`: `SdkRequests`, `SbomgenRunner`, `SbomgenDownloader`, `SbomgenUtils`, `Sanitizer`
- `getImageSha`: switched to `printStackTrace` for consistency with the rest of the error logging
- Removed an unused `SuppressFBWarnings` import in `SbomgenUtils`

## Design notes

- `getLogger()`/`setLogger()` are kept `static` (matching the prior static accessor) because callers like `SdkRequests` and `SbomgenRunner` log without holding a builder instance. The fix is replacing the reassignable shared field with thread-isolated storage and a controlled accessor — not changing how callers reach the logger.
- Threading the logger through constructors as an instance field would be cleaner OO but a much larger change across the sbomgen/SDK classes; left as a possible future refinement.

## Tests

- Added `AmazonInspectorBuilderLoggerTest`: fallback-to-System.out, set/get, clear, and a concurrent-build test proving two threads writing simultaneously each receive only their own output
- 88 tests pass, `mvn verify` clean, 0 SpotBugs violations
- Live verified in Jenkins: two concurrent `ubuntu:18.04` scans each produced a clean, isolated console with no cross-talk, both SUCCESS
<img width="2524" height="1020" alt="Screenshot 2026-06-03 at 9 46 00 AM" src="https://github.com/user-attachments/assets/f73ac6ad-1c3d-4009-a75c-9fc185418e82" />
<img width="2524" height="1020" alt="Screenshot 2026-06-03 at 9 46 16 AM" src="https://github.com/user-attachments/assets/72ce5fc7-f1bb-4e29-b485-0239296ec5f2" />
