### PR TITLE
ci: build and verify on Linux/JDK21 and Windows/JDK17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,27 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }} / JDK ${{ matrix.jdk }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            os: ubuntu-latest
+            jdk: 21
+          - platform: windows
+            os: windows-latest
+            jdk: 17
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: ${{ matrix.jdk }}
           cache: maven
 
       - name: Build and verify


### PR DESCRIPTION
## What

The dev CI built only on Linux/JDK21, while the release repo gates on both Linux/JDK21 and Windows/JDK17. This adds a build matrix so dev runs the same platform + JDK combinations.

A green check on dev now means a change (including dependency bumps) passes everywhere the release repo cares about — so we catch Windows or JDK17 issues here before they sync to the release repo, instead of after.

## Changes

- `.github/workflows/build.yml`: converted the single Linux/JDK21 job into a matrix
  - linux / ubuntu-latest / JDK 21
  - windows / windows-latest / JDK 17
- `fail-fast: false` so both legs always run
- added `timeout-minutes: 30` to bound stuck builds

No code changes — CI configuration only.
