### PR TITLE
fix: degrade gracefully on malformed SBOM data instead of failing the…

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtils.java
@@ -73,9 +73,19 @@ public class HtmlConversionUtils {
 
         for (Property property : properties) {
             if (property.getName().contains(id)) {
-                String lines = property.getValue().split(":")[1];
+                String value = property.getValue();
+                if (value == null) {
+                    return "N/A";
+                }
+
+                String[] valueParts = value.split(":");
+                if (valueParts.length < 2) {
+                    return "N/A";
+                }
+
+                String lines = valueParts[1];
                 String[] splitLines = lines.split("-");
-                if (splitLines[0].equals(splitLines[1])) {
+                if (splitLines.length >= 2 && splitLines[0].equals(splitLines[1])) {
                     return splitLines[0];
                 } else {
                     return lines;
@@ -94,7 +104,7 @@ public class HtmlConversionUtils {
         }
 
         for (Component component : components) {
-            if (component.getName() != null && component.getName().contains("dockerfile")) {
+            if (component != null && component.getName() != null && component.getName().contains("dockerfile")) {
                 lineComponents.add(component);
             }
         }
@@ -131,10 +141,10 @@ public class HtmlConversionUtils {
                 if (lineComponent != null)  {
                     lines = getLines(vulnerability.getId(), lineComponent.getProperties());
                     filename = lineComponent.getName();
-                }
 
-                if (lineComponent.getName().equals("dockerfile:comp-1.Dockerfile")) {
-                    lines += " - Derived";
+                    if ("dockerfile:comp-1.Dockerfile".equals(lineComponent.getName())) {
+                        lines += " - Derived";
+                    }
                 }
             }
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtils.java
@@ -1,6 +1,5 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils;
 
-import com.amazon.inspector.jenkins.amazoninspectorbuildstep.AmazonInspectorBuilder;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Rating;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity;
@@ -30,15 +29,18 @@ public class ConversionUtils {
 
         Map<String, Severity> severityMap = new HashMap<>();
         for (Rating rating : ratings) {
-            if (rating == null) {
+            if (rating == null || rating.getSource() == null || rating.getMethod() == null) {
                 continue;
             }
 
             String sourceName = rating.getSource().getName();
             String method = rating.getMethod();
 
-            if (sourceName.equals(NVD)) {
-                severityMap.put(getCvssMethod(method), Severity.getSeverityFromString(rating.getSeverity()));
+            if (NVD.equals(sourceName)) {
+                String cvssMethod = getCvssMethod(method);
+                if (cvssMethod != null) {
+                    severityMap.put(cvssMethod, Severity.getSeverityFromString(rating.getSeverity()));
+                }
             }
         }
 
@@ -56,7 +58,8 @@ public class ConversionUtils {
             return CVSS2;
         }
 
-        throw new RuntimeException("Unsupported CVSS method: " + method);
+        // Unknown/unsupported CVSS method: skip this rating rather than failing the whole scan.
+        return null;
     }
 
     private static Severity getHighestCvssMethodSeverity(Map<String, Severity> severityMap) {

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/html/HtmlConversionUtilsTest.java
@@ -188,6 +188,34 @@ class HtmlConversionUtilsTest {
     }
 
     @Test
+    void testConvertDocker_nullLineComponentDoesNotThrow() {
+        // A null entry among the dockerfile components must be skipped, not dereferenced.
+        Vulnerability vulnerability = Vulnerability.builder()
+                .id("IN-DOCKER")
+                .ratings(List.of(Rating.builder().source(
+                                Source.builder().name("NVD").build()
+                        )
+                        .method("CVSSv4")
+                        .severity("HIGH").build()))
+                .affects(List.of(Affect.builder().ref("bom").build()))
+                .build();
+        List<Vulnerability> vulnerabilities = List.of(vulnerability);
+
+        Component realDockerfile = Component.builder()
+                .bomRef("bom")
+                .name("dockerfile")
+                .purl("purl")
+                .build();
+        // Arrays.asList allows a null element, unlike List.of.
+        List<Component> components = java.util.Arrays.asList(null, realDockerfile);
+
+        List<DockerVulnerability> dockerVulnerabilities =
+                HtmlConversionUtils.convertDocker(vulnerabilities, components);
+
+        assertEquals(1, dockerVulnerabilities.size());
+    }
+
+    @Test
     void testConvertDocker_derivedDockerfile() {
         Vulnerability vulnerability = Vulnerability.builder()
                 .id("IN-DOCKER")
@@ -245,6 +273,39 @@ class HtmlConversionUtilsTest {
                 .name(id)
                 .build());
         assertEquals("N/A", HtmlConversionUtils.getLines("invalid", properties));
+    }
+
+    @Test
+    void testGetLines_valueWithoutColon() {
+        // Malformed property value with no ":" must not throw ArrayIndexOutOfBoundsException.
+        String id = "testId";
+        List<Property> properties = List.of(Property.builder()
+                .value("noColonHere")
+                .name(id)
+                .build());
+        assertEquals("N/A", HtmlConversionUtils.getLines(id, properties));
+    }
+
+    @Test
+    void testGetLines_nullValue() {
+        // Property with a null value must degrade to N/A rather than NPE.
+        String id = "testId";
+        List<Property> properties = List.of(Property.builder()
+                .value(null)
+                .name(id)
+                .build());
+        assertEquals("N/A", HtmlConversionUtils.getLines(id, properties));
+    }
+
+    @Test
+    void testGetLines_valueWithoutDash() {
+        // Value with a ":" but no "-" segment returns the raw segment instead of crashing.
+        String id = "testId";
+        List<Property> properties = List.of(Property.builder()
+                .value("affected_lines:6")
+                .name(id)
+                .build());
+        assertEquals("6", HtmlConversionUtils.getLines(id, properties));
     }
 
     @Test

--- a/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtilsTest.java
+++ b/src/test/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/utils/ConversionUtilsTest.java
@@ -1,6 +1,8 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.utils;
 
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.TestUtils;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Rating;
+import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Source;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.Components.Vulnerability;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.models.sbom.SbomData;
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 class ConversionUtilsTest {
@@ -37,5 +40,67 @@ class ConversionUtilsTest {
         assertEquals(Integer.valueOf(110), severityMap.get(Severity.MEDIUM));
         assertEquals(Integer.valueOf(9), severityMap.get(Severity.LOW));
         assertEquals(Integer.valueOf(0), severityMap.get(Severity.OTHER));
+    }
+
+    @Test
+    void getSeverity_unknownCvssMethod_returnsUntriagedInsteadOfThrowing() {
+        // An unrecognized CVSS method (e.g. a future version) must not crash the scan.
+        Vulnerability vuln = Vulnerability.builder()
+                .ratings(List.of(Rating.builder()
+                        .severity("HIGH")
+                        .method("CVSSv9")
+                        .source(Source.builder().name("NVD").build())
+                        .build()))
+                .build();
+
+        assertEquals(Severity.UNTRIAGED, ConversionUtils.getSeverity(vuln));
+    }
+
+    @Test
+    void getSeverity_nullSource_isSkipped() {
+        // A rating with a null source must be skipped rather than throwing an NPE.
+        Vulnerability vuln = Vulnerability.builder()
+                .ratings(List.of(Rating.builder()
+                        .severity("HIGH")
+                        .method("CVSSv4")
+                        .source(null)
+                        .build()))
+                .build();
+
+        assertEquals(Severity.UNTRIAGED, ConversionUtils.getSeverity(vuln));
+    }
+
+    @Test
+    void getSeverity_nullMethod_isSkipped() {
+        // A rating with a null method must be skipped rather than throwing an NPE.
+        Vulnerability vuln = Vulnerability.builder()
+                .ratings(List.of(Rating.builder()
+                        .severity("HIGH")
+                        .method(null)
+                        .source(Source.builder().name("NVD").build())
+                        .build()))
+                .build();
+
+        assertEquals(Severity.UNTRIAGED, ConversionUtils.getSeverity(vuln));
+    }
+
+    @Test
+    void getSeverity_knownMethodAlongsideUnknown_stillResolves() {
+        // A valid NVD/CVSSv4 rating should still resolve even if another rating has an unknown method.
+        Vulnerability vuln = Vulnerability.builder()
+                .ratings(List.of(
+                        Rating.builder()
+                                .severity("CRITICAL")
+                                .method("CVSSv4")
+                                .source(Source.builder().name("NVD").build())
+                                .build(),
+                        Rating.builder()
+                                .severity("LOW")
+                                .method("CVSSv9")
+                                .source(Source.builder().name("NVD").build())
+                                .build()))
+                .build();
+
+        assertEquals(Severity.CRITICAL, ConversionUtils.getSeverity(vuln));
     }
 }


### PR DESCRIPTION
## What

Several SBOM-parsing paths assumed perfectly-formed scan output and would crash the entire build on unexpected data. This makes them degrade gracefully so a single malformed entry is skipped rather than failing the whole scan.

## Changes

- **ConversionUtils.getSeverity**
  - Unknown/unsupported CVSS method now skips the rating instead of throwing `RuntimeException`
  - Guards ratings with a null source or null method (previously NPE'd)
  - Removed an unused import
- **HtmlConversionUtils.getLines**
  - Guards null property values and values missing the expected `:` / `-` delimiters (previously threw ArrayIndexOutOfBoundsException), falling back to `"N/A"`
- **HtmlConversionUtils.getLineComponents / convertDocker**
  - Skips null components and moved the derived-dockerfile check inside the null guard (previously NPE'd on a null component)

## Tests

- 8 new tests covering each malformed-input case (unknown CVSS method, null source, null method, mixed valid/invalid ratings, missing colon/dash, null value, null component)
- Existing `testGetSeverities` still asserts the exact same severity counts against the real Ubuntu SBOM fixture, confirming no behavior change for valid data
- 96 tests pass, `mvn verify` clean, 0 SpotBugs violations
- Live verified: `ubuntu:18.04` scan → SUCCESS, report + CSV generated

<img width="1667" height="853" alt="image" src="https://github.com/user-attachments/assets/37474e0e-cefb-4075-b9f7-84fb36b5785e" />

